### PR TITLE
Implement DOM Living Standard API ("Level 4")

### DIFF
--- a/ext/dom/characterdata.c
+++ b/ext/dom/characterdata.c
@@ -51,6 +51,15 @@ ZEND_BEGIN_ARG_INFO_EX(arginfo_dom_characterdata_replace_data, 0, 0, 3)
 	ZEND_ARG_INFO(0, count)
 	ZEND_ARG_INFO(0, arg)
 ZEND_END_ARG_INFO();
+
+ZEND_BEGIN_ARG_INFO_EX(arginfo_dom_characterdata_remove, 0, 0, 0)
+ZEND_END_ARG_INFO();
+
+ZEND_BEGIN_ARG_INFO_EX(arginfo_dom_characterdata_after, 0, 0, 0)
+ZEND_END_ARG_INFO();
+
+ZEND_BEGIN_ARG_INFO_EX(arginfo_dom_characterdata_before, 0, 0, 0)
+ZEND_END_ARG_INFO();
 /* }}} */
 
 /*
@@ -66,6 +75,9 @@ const zend_function_entry php_dom_characterdata_class_functions[] = {
 	PHP_FALIAS(insertData, dom_characterdata_insert_data, arginfo_dom_characterdata_insert_data)
 	PHP_FALIAS(deleteData, dom_characterdata_delete_data, arginfo_dom_characterdata_delete_data)
 	PHP_FALIAS(replaceData, dom_characterdata_replace_data, arginfo_dom_characterdata_replace_data)
+	PHP_ME(domcharacterdata, remove, arginfo_dom_characterdata_remove, ZEND_ACC_PUBLIC)
+	PHP_ME(domcharacterdata, after, arginfo_dom_characterdata_after, ZEND_ACC_PUBLIC)
+	PHP_ME(domcharacterdata, before, arginfo_dom_characterdata_before, ZEND_ACC_PUBLIC)
 	PHP_FE_END
 };
 
@@ -386,5 +398,88 @@ PHP_FUNCTION(dom_characterdata_replace_data)
 	RETURN_TRUE;
 }
 /* }}} end dom_characterdata_replace_data */
+
+PHP_METHOD(domcharacterdata, remove)
+{
+	zval *id;
+	xmlNodePtr children, child;
+	dom_object *intern;
+	int stricterror;
+
+	id = ZEND_THIS;
+	if (zend_parse_parameters_none() == FAILURE) {
+		return;
+	}
+
+	DOM_GET_OBJ(child, id, xmlNodePtr, intern);
+
+	if (dom_node_children_valid(child) == FAILURE) {
+		RETURN_NULL();
+	}
+
+	stricterror = dom_get_strict_error(intern->document);
+
+	if (dom_node_is_read_only(child) == SUCCESS ||
+		(child->parent != NULL && dom_node_is_read_only(child->parent) == SUCCESS)) {
+		php_dom_throw_error(NO_MODIFICATION_ALLOWED_ERR, stricterror);
+		RETURN_NULL();
+	}
+
+	if (!child->parent) {
+		php_dom_throw_error(NOT_FOUND_ERR, stricterror);
+		RETURN_NULL();
+	}
+
+	children = child->parent->children;
+	if (!children) {
+		php_dom_throw_error(NOT_FOUND_ERR, stricterror);
+		RETURN_NULL();
+	}
+
+	while (children) {
+		if (children == child) {
+			xmlUnlinkNode(child);
+			RETURN_NULL();
+		}
+		children = children->next;
+	}
+
+	php_dom_throw_error(NOT_FOUND_ERR, stricterror);
+	RETURN_NULL();
+}
+
+PHP_METHOD(domcharacterdata, after)
+{
+	int argc;
+	zval *args, *id;
+	dom_object *intern;
+	xmlNode *context;
+
+	if (zend_parse_parameters(ZEND_NUM_ARGS(), "+", &args, &argc) == FAILURE) {
+		return;
+	}
+
+	id = ZEND_THIS;
+	DOM_GET_OBJ(context, id, xmlNodePtr, intern);
+
+	dom_parent_node_after(intern, args, argc);
+}
+
+PHP_METHOD(domcharacterdata, before)
+{
+	int argc;
+	zval *args, *id;
+	dom_object *intern;
+	xmlNode *context;
+
+	if (zend_parse_parameters(ZEND_NUM_ARGS(), "+", &args, &argc) == FAILURE) {
+		return;
+	}
+
+	id = ZEND_THIS;
+	DOM_GET_OBJ(context, id, xmlNodePtr, intern);
+
+	dom_parent_node_before(intern, args, argc);
+}
 
 #endif

--- a/ext/dom/config.m4
+++ b/ext/dom/config.m4
@@ -18,6 +18,7 @@ if test "$PHP_DOM" != "no"; then
     AC_DEFINE(HAVE_DOM,1,[ ])
     PHP_NEW_EXTENSION(dom, [php_dom.c attr.c document.c domerrorhandler.c \
                             domstringlist.c domexception.c namelist.c \
+                            parentnode.c \
                             processinginstruction.c cdatasection.c \
                             documentfragment.c domimplementation.c \
                             element.c node.c string_extend.c characterdata.c \

--- a/ext/dom/config.w32
+++ b/ext/dom/config.w32
@@ -9,6 +9,7 @@ if (PHP_DOM == "yes") {
 	) {
 		EXTENSION("dom", "php_dom.c attr.c document.c domerrorhandler.c \
 			domstringlist.c domexception.c namelist.c processinginstruction.c \
+			parentnode.c \
 			cdatasection.c documentfragment.c domimplementation.c element.c \
 			node.c string_extend.c characterdata.c documenttype.c \
 			domimplementationlist.c entity.c nodelist.c text.c comment.c \

--- a/ext/dom/document.c
+++ b/ext/dom/document.c
@@ -2280,10 +2280,19 @@ PHP_METHOD(domdocument, registerNodeClass)
 }
 /* }}} */
 
+/* {{{ proto void domdocument::append(string|DOMNode ...$nodes)
+URL: https://dom.spec.whatwg.org/#dom-parentnode-append
+Since: DOM Living Standard (DOM4)
+*/
 PHP_METHOD(domdocument, append)
 {
 }
+/* }}} */
 
+/* {{{ proto void domdocument::prepend(string|DOMNode ...$nodes)
+URL: https://dom.spec.whatwg.org/#dom-parentnode-prepend
+Since: DOM Living Standard (DOM4)
+*/
 PHP_METHOD(domdocument, prepend)
 {
 }

--- a/ext/dom/document.c
+++ b/ext/dom/document.c
@@ -2286,6 +2286,19 @@ Since: DOM Living Standard (DOM4)
 */
 PHP_METHOD(domdocument, append)
 {
+	int argc;
+	zval *args, *id;
+	dom_object *intern;
+	xmlNode *context;
+
+	if (zend_parse_parameters(ZEND_NUM_ARGS(), "+", &args, &argc) == FAILURE) {
+		return;
+	}
+
+	id = ZEND_THIS;
+	DOM_GET_OBJ(context, id, xmlNodePtr, intern);
+
+	dom_parent_node_append(intern, args, argc);
 }
 /* }}} */
 
@@ -2295,6 +2308,24 @@ Since: DOM Living Standard (DOM4)
 */
 PHP_METHOD(domdocument, prepend)
 {
+	int argc;
+	zval *args, *id;
+	dom_object *intern;
+	xmlNode *context;
+
+	if (zend_parse_parameters(ZEND_NUM_ARGS(), "+", &args, &argc) == FAILURE) {
+		return;
+	}
+
+	id = ZEND_THIS;
+	DOM_GET_OBJ(context, id, xmlNodePtr, intern);
+
+	if (context->children == NULL) {
+		dom_parent_node_append(intern, args, argc);
+	} else {
+		dom_parent_node_prepend(intern, args, argc);
+	}
 }
+/* }}} */
 
 #endif  /* HAVE_LIBXML && HAVE_DOM */

--- a/ext/dom/document.c
+++ b/ext/dom/document.c
@@ -183,6 +183,12 @@ ZEND_BEGIN_ARG_INFO_EX(arginfo_dom_document_registernodeclass, 0, 0, 2)
 	ZEND_ARG_INFO(0, baseClass)
 	ZEND_ARG_INFO(0, extendedClass)
 ZEND_END_ARG_INFO();
+
+ZEND_BEGIN_ARG_INFO_EX(arginfo_dom_document_append, 0, 0, 0)
+ZEND_END_ARG_INFO();
+
+ZEND_BEGIN_ARG_INFO_EX(arginfo_dom_document_prepend, 0, 0, 0)
+ZEND_END_ARG_INFO();
 /* }}} */
 
 /*
@@ -230,6 +236,8 @@ const zend_function_entry php_dom_document_class_functions[] = { /* {{{ */
 	PHP_FALIAS(relaxNGValidateSource, dom_document_relaxNG_validate_xml, arginfo_dom_document_relaxNG_validate_xml)
 #endif
 	PHP_ME(domdocument, registerNodeClass, arginfo_dom_document_registernodeclass, ZEND_ACC_PUBLIC)
+	PHP_ME(domdocument, append, arginfo_dom_document_append, ZEND_ACC_PUBLIC)
+	PHP_ME(domdocument, prepend, arginfo_dom_document_prepend, ZEND_ACC_PUBLIC)
 	PHP_FE_END
 };
 /* }}} */
@@ -2271,5 +2279,13 @@ PHP_METHOD(domdocument, registerNodeClass)
 	RETURN_FALSE;
 }
 /* }}} */
+
+PHP_METHOD(domdocument, append)
+{
+}
+
+PHP_METHOD(domdocument, prepend)
+{
+}
 
 #endif  /* HAVE_LIBXML && HAVE_DOM */

--- a/ext/dom/documentfragment.c
+++ b/ext/dom/documentfragment.c
@@ -155,11 +155,22 @@ PHP_METHOD(domdocumentfragment, appendXML) {
 }
 /* }}} */
 
+/* {{{ proto void domdocumentfragment::append(string|DOMNode ...$nodes)
+URL: https://dom.spec.whatwg.org/#dom-parentnode-append
+Since: DOM Living Standard (DOM4)
+*/
 PHP_METHOD(domdocumentfragment, append)
 {
 }
+/* }}} */
 
+/* {{{ proto void domdocumentfragment::prepend(string|DOMNode ...$nodes)
+URL: https://dom.spec.whatwg.org/#dom-parentnode-prepend
+Since: DOM Living Standard (DOM4)
+*/
 PHP_METHOD(domdocumentfragment, prepend)
 {
 }
+/* }}} */
+
 #endif

--- a/ext/dom/documentfragment.c
+++ b/ext/dom/documentfragment.c
@@ -161,6 +161,19 @@ Since: DOM Living Standard (DOM4)
 */
 PHP_METHOD(domdocumentfragment, append)
 {
+	int argc;
+	zval *args, *id;
+	dom_object *intern;
+	xmlNode *context;
+
+	if (zend_parse_parameters(ZEND_NUM_ARGS(), "+", &args, &argc) == FAILURE) {
+		return;
+	}
+
+	id = ZEND_THIS;
+	DOM_GET_OBJ(context, id, xmlNodePtr, intern);
+
+	dom_parent_node_append(intern, args, argc);
 }
 /* }}} */
 
@@ -170,6 +183,23 @@ Since: DOM Living Standard (DOM4)
 */
 PHP_METHOD(domdocumentfragment, prepend)
 {
+	int argc;
+	zval *args, *id;
+	dom_object *intern;
+	xmlNode *context;
+
+	if (zend_parse_parameters(ZEND_NUM_ARGS(), "+", &args, &argc) == FAILURE) {
+		return;
+	}
+
+	id = ZEND_THIS;
+	DOM_GET_OBJ(context, id, xmlNodePtr, intern);
+
+	if (context->children == NULL) {
+		dom_parent_node_append(intern, args, argc);
+	} else {
+		dom_parent_node_prepend(intern, args, argc);
+	}
 }
 /* }}} */
 

--- a/ext/dom/documentfragment.c
+++ b/ext/dom/documentfragment.c
@@ -32,6 +32,12 @@ ZEND_END_ARG_INFO();
 ZEND_BEGIN_ARG_INFO_EX(arginfo_dom_documentfragement_appendXML, 0, 0, 1)
 	ZEND_ARG_INFO(0, data)
 ZEND_END_ARG_INFO();
+
+ZEND_BEGIN_ARG_INFO_EX(arginfo_dom_documentfragment_append, 0, 0, 0)
+ZEND_END_ARG_INFO();
+
+ZEND_BEGIN_ARG_INFO_EX(arginfo_dom_documentfragment_prepend, 0, 0, 0)
+ZEND_END_ARG_INFO();
 /* }}} */
 
 /*
@@ -44,6 +50,8 @@ ZEND_END_ARG_INFO();
 const zend_function_entry php_dom_documentfragment_class_functions[] = {
 	PHP_ME(domdocumentfragment, __construct, arginfo_dom_documentfragement_construct, ZEND_ACC_PUBLIC)
 	PHP_ME(domdocumentfragment, appendXML, arginfo_dom_documentfragement_appendXML, ZEND_ACC_PUBLIC)
+	PHP_ME(domdocumentfragment, append, arginfo_dom_documentfragment_append, ZEND_ACC_PUBLIC)
+	PHP_ME(domdocumentfragment, prepend, arginfo_dom_documentfragment_prepend, ZEND_ACC_PUBLIC)
 	PHP_FE_END
 };
 
@@ -147,4 +155,11 @@ PHP_METHOD(domdocumentfragment, appendXML) {
 }
 /* }}} */
 
+PHP_METHOD(domdocumentfragment, append)
+{
+}
+
+PHP_METHOD(domdocumentfragment, prepend)
+{
+}
 #endif

--- a/ext/dom/dom_fe.h
+++ b/ext/dom/dom_fe.h
@@ -195,6 +195,9 @@ PHP_FUNCTION(dom_characterdata_append_data);
 PHP_FUNCTION(dom_characterdata_insert_data);
 PHP_FUNCTION(dom_characterdata_delete_data);
 PHP_FUNCTION(dom_characterdata_replace_data);
+PHP_METHOD(domcharacterdata, remove);
+PHP_METHOD(domcharacterdata, after);
+PHP_METHOD(domcharacterdata, before);
 
 /* domattr methods */
 PHP_FUNCTION(dom_attr_is_id);

--- a/ext/dom/dom_fe.h
+++ b/ext/dom/dom_fe.h
@@ -217,6 +217,7 @@ PHP_FUNCTION(dom_element_set_id_attribute_ns);
 PHP_FUNCTION(dom_element_set_id_attribute_node);
 PHP_METHOD(domelement, __construct);
 PHP_METHOD(domelement, remove);
+PHP_METHOD(domelement, append);
 
 /* domtext methods */
 PHP_FUNCTION(dom_text_split_text);

--- a/ext/dom/dom_fe.h
+++ b/ext/dom/dom_fe.h
@@ -24,6 +24,7 @@ extern const zend_function_entry php_dom_domexception_class_functions[];
 extern const zend_function_entry php_dom_domstringlist_class_functions[];
 extern const zend_function_entry php_dom_namelist_class_functions[];
 extern const zend_function_entry php_dom_parent_node_class_functions[];
+extern const zend_function_entry php_dom_child_node_class_functions[];
 extern const zend_function_entry php_dom_domimplementationlist_class_functions[];
 extern const zend_function_entry php_dom_domimplementationsource_class_functions[];
 extern const zend_function_entry php_dom_domimplementation_class_functions[];
@@ -215,6 +216,7 @@ PHP_FUNCTION(dom_element_set_id_attribute);
 PHP_FUNCTION(dom_element_set_id_attribute_ns);
 PHP_FUNCTION(dom_element_set_id_attribute_node);
 PHP_METHOD(domelement, __construct);
+PHP_METHOD(domelement, remove);
 
 /* domtext methods */
 PHP_FUNCTION(dom_text_split_text);

--- a/ext/dom/dom_fe.h
+++ b/ext/dom/dom_fe.h
@@ -104,6 +104,8 @@ PHP_METHOD(domimplementation, getFeature);
 /* domdocumentfragment methods */
 PHP_METHOD(domdocumentfragment, __construct);
 PHP_METHOD(domdocumentfragment, appendXML);
+PHP_METHOD(domdocumentfragment, append);
+PHP_METHOD(domdocumentfragment, prepend);
 
 /* domdocument methods */
 PHP_FUNCTION(dom_document_create_element);
@@ -132,6 +134,8 @@ PHP_FUNCTION(dom_document_savexml);
 PHP_FUNCTION(dom_document_validate);
 PHP_FUNCTION(dom_document_xinclude);
 PHP_METHOD(domdocument, registerNodeClass);
+PHP_METHOD(domdocument, append);
+PHP_METHOD(domdocument, prepend);
 
 #if defined(LIBXML_HTML_ENABLED)
 PHP_METHOD(domdocument, loadHTML);

--- a/ext/dom/dom_fe.h
+++ b/ext/dom/dom_fe.h
@@ -23,6 +23,7 @@
 extern const zend_function_entry php_dom_domexception_class_functions[];
 extern const zend_function_entry php_dom_domstringlist_class_functions[];
 extern const zend_function_entry php_dom_namelist_class_functions[];
+extern const zend_function_entry php_dom_parent_node_class_functions[];
 extern const zend_function_entry php_dom_domimplementationlist_class_functions[];
 extern const zend_function_entry php_dom_domimplementationsource_class_functions[];
 extern const zend_function_entry php_dom_domimplementation_class_functions[];

--- a/ext/dom/dom_fe.h
+++ b/ext/dom/dom_fe.h
@@ -218,6 +218,7 @@ PHP_FUNCTION(dom_element_set_id_attribute_node);
 PHP_METHOD(domelement, __construct);
 PHP_METHOD(domelement, remove);
 PHP_METHOD(domelement, append);
+PHP_METHOD(domelement, prepend);
 
 /* domtext methods */
 PHP_FUNCTION(dom_text_split_text);

--- a/ext/dom/dom_fe.h
+++ b/ext/dom/dom_fe.h
@@ -221,6 +221,8 @@ PHP_FUNCTION(dom_element_set_id_attribute_ns);
 PHP_FUNCTION(dom_element_set_id_attribute_node);
 PHP_METHOD(domelement, __construct);
 PHP_METHOD(domelement, remove);
+PHP_METHOD(domelement, after);
+PHP_METHOD(domelement, before);
 PHP_METHOD(domelement, append);
 PHP_METHOD(domelement, prepend);
 

--- a/ext/dom/dom_properties.h
+++ b/ext/dom/dom_properties.h
@@ -129,6 +129,8 @@ int dom_node_first_child_read(dom_object *obj, zval *retval);
 int dom_node_last_child_read(dom_object *obj, zval *retval);
 int dom_node_previous_sibling_read(dom_object *obj, zval *retval);
 int dom_node_next_sibling_read(dom_object *obj, zval *retval);
+int dom_node_previous_element_sibling_read(dom_object *obj, zval *retval);
+int dom_node_next_element_sibling_read(dom_object *obj, zval *retval);
 int dom_node_attributes_read(dom_object *obj, zval *retval);
 int dom_node_owner_document_read(dom_object *obj, zval *retval);
 int dom_node_namespace_uri_read(dom_object *obj, zval *retval);

--- a/ext/dom/dom_properties.h
+++ b/ext/dom/dom_properties.h
@@ -113,6 +113,11 @@ int dom_namednodemap_length_read(dom_object *obj, zval *retval);
 /* namelist properties */
 int dom_namelist_length_read(dom_object *obj, zval *retval);
 
+/* parent node properties */
+int dom_parent_node_first_element_child_read(dom_object *obj, zval *retval);
+int dom_parent_node_last_element_child_read(dom_object *obj, zval *retval);
+int dom_parent_node_child_element_count(dom_object *obj, zval *retval);
+
 /* node properties */
 int dom_node_node_name_read(dom_object *obj, zval *retval);
 int dom_node_node_value_read(dom_object *obj, zval *retval);

--- a/ext/dom/element.c
+++ b/ext/dom/element.c
@@ -119,6 +119,12 @@ ZEND_END_ARG_INFO();
 ZEND_BEGIN_ARG_INFO_EX(arginfo_dom_element_remove, 0, 0, 0)
 ZEND_END_ARG_INFO();
 
+ZEND_BEGIN_ARG_INFO_EX(arginfo_dom_element_after, 0, 0, 0)
+ZEND_END_ARG_INFO();
+
+ZEND_BEGIN_ARG_INFO_EX(arginfo_dom_element_before, 0, 0, 0)
+ZEND_END_ARG_INFO();
+
 ZEND_BEGIN_ARG_INFO_EX(arginfo_dom_element_append, 0, 0, 0)
 ZEND_END_ARG_INFO();
 
@@ -154,6 +160,8 @@ const zend_function_entry php_dom_element_class_functions[] = { /* {{{ */
 	PHP_FALIAS(setIdAttributeNode, dom_element_set_id_attribute_node, arginfo_dom_element_set_id_attribute_node)
 	PHP_ME(domelement, __construct, arginfo_dom_element_construct, ZEND_ACC_PUBLIC)
 	PHP_ME(domelement, remove, arginfo_dom_element_remove, ZEND_ACC_PUBLIC)
+	PHP_ME(domelement, after, arginfo_dom_element_after, ZEND_ACC_PUBLIC)
+	PHP_ME(domelement, before, arginfo_dom_element_before, ZEND_ACC_PUBLIC)
 	PHP_ME(domelement, append, arginfo_dom_element_append, ZEND_ACC_PUBLIC)
 	PHP_ME(domelement, prepend, arginfo_dom_element_prepend, ZEND_ACC_PUBLIC)
 	PHP_FE_END
@@ -1341,6 +1349,14 @@ PHP_METHOD(domelement, remove)
 	RETURN_NULL();
 }
 /* }}} end DOMElement::remove */
+
+PHP_METHOD(domelement, after)
+{
+}
+
+PHP_METHOD(domelement, before)
+{
+}
 
 /* {{{ proto void domelement::append(string|DOMNode ...$nodes)
 URL: https://dom.spec.whatwg.org/#dom-parentnode-append

--- a/ext/dom/element.c
+++ b/ext/dom/element.c
@@ -1342,9 +1342,9 @@ PHP_METHOD(domelement, remove)
 }
 /* }}} end DOMElement::remove */
 
-/* {{{ proto void DOMElement::append();
-URL:
-Since:
+/* {{{ proto void domelement::append(string|DOMNode ...$nodes)
+URL: https://dom.spec.whatwg.org/#dom-parentnode-append
+Since: DOM Living Standard (DOM4)
 */
 PHP_METHOD(domelement, append)
 {
@@ -1364,9 +1364,9 @@ PHP_METHOD(domelement, append)
 }
 /* }}} end DOMElement::append */
 
-/* {{{ proto void DOMElement::prepend();
-URL:
-Since:
+/* {{{ proto void domelement::prepend(string|DOMNode ...$nodes)
+URL: https://dom.spec.whatwg.org/#dom-parentnode-prepend
+Since: DOM Living Standard (DOM4)
 */
 PHP_METHOD(domelement, prepend)
 {

--- a/ext/dom/element.c
+++ b/ext/dom/element.c
@@ -1352,10 +1352,36 @@ PHP_METHOD(domelement, remove)
 
 PHP_METHOD(domelement, after)
 {
+	int argc;
+	zval *args, *id;
+	dom_object *intern;
+	xmlNode *context;
+
+	if (zend_parse_parameters(ZEND_NUM_ARGS(), "+", &args, &argc) == FAILURE) {
+		return;
+	}
+
+	id = ZEND_THIS;
+	DOM_GET_OBJ(context, id, xmlNodePtr, intern);
+
+	dom_parent_node_after(intern, args, argc);
 }
 
 PHP_METHOD(domelement, before)
 {
+	int argc;
+	zval *args, *id;
+	dom_object *intern;
+	xmlNode *context;
+
+	if (zend_parse_parameters(ZEND_NUM_ARGS(), "+", &args, &argc) == FAILURE) {
+		return;
+	}
+
+	id = ZEND_THIS;
+	DOM_GET_OBJ(context, id, xmlNodePtr, intern);
+
+	dom_parent_node_before(intern, args, argc);
 }
 
 /* {{{ proto void domelement::append(string|DOMNode ...$nodes)

--- a/ext/dom/element.c
+++ b/ext/dom/element.c
@@ -1280,7 +1280,7 @@ PHP_FUNCTION(dom_element_set_id_attribute_node)
 }
 /* }}} end dom_element_set_id_attribute_node */
 
-/* {{{ proto DomChildNode DOMElement::remove();
+/* {{{ proto void DOMElement::remove();
 URL:
 Since:
 */
@@ -1299,7 +1299,7 @@ PHP_METHOD(domelement, remove)
 	DOM_GET_OBJ(child, id, xmlNodePtr, intern);
 
 	if (dom_node_children_valid(child) == FAILURE) {
-		RETURN_FALSE;
+		RETURN_NULL();
 	}
 
 	stricterror = dom_get_strict_error(intern->document);
@@ -1307,31 +1307,30 @@ PHP_METHOD(domelement, remove)
 	if (dom_node_is_read_only(child) == SUCCESS ||
 		(child->parent != NULL && dom_node_is_read_only(child->parent) == SUCCESS)) {
 		php_dom_throw_error(NO_MODIFICATION_ALLOWED_ERR, stricterror);
-		RETURN_FALSE;
+		RETURN_NULL();
 	}
 
 	if (!child->parent) {
 		php_dom_throw_error(NOT_FOUND_ERR, stricterror);
-		RETURN_FALSE;
+		RETURN_NULL();
 	}
 
 	children = child->parent->children;
 	if (!children) {
 		php_dom_throw_error(NOT_FOUND_ERR, stricterror);
-		RETURN_FALSE;
+		RETURN_NULL();
 	}
 
 	while (children) {
 		if (children == child) {
 			xmlUnlinkNode(child);
-			DOM_RET_OBJ(child, &ret, intern);
-			return;
+			RETURN_NULL();
 		}
 		children = children->next;
 	}
 
 	php_dom_throw_error(NOT_FOUND_ERR, stricterror);
-	RETURN_FALSE
+	RETURN_NULL();
 }
 /* }}} end dom_node_remove_child */
 

--- a/ext/dom/element.c
+++ b/ext/dom/element.c
@@ -1292,7 +1292,7 @@ PHP_METHOD(domelement, remove)
 	int ret, stricterror;
 
 	id = ZEND_THIS;
-	if (zend_parse_parameters(ZEND_NUM_ARGS(), "O", &node, dom_node_class_entry) == FAILURE) {
+	if (zend_parse_parameters_none() == FAILURE) {
 		return;
 	}
 

--- a/ext/dom/element.c
+++ b/ext/dom/element.c
@@ -121,6 +121,9 @@ ZEND_END_ARG_INFO();
 
 ZEND_BEGIN_ARG_INFO_EX(arginfo_dom_element_append, 0, 0, 0)
 ZEND_END_ARG_INFO();
+
+ZEND_BEGIN_ARG_INFO_EX(arginfo_dom_element_prepend, 0, 0, 0)
+ZEND_END_ARG_INFO();
 /* }}} */
 
 /*
@@ -152,6 +155,7 @@ const zend_function_entry php_dom_element_class_functions[] = { /* {{{ */
 	PHP_ME(domelement, __construct, arginfo_dom_element_construct, ZEND_ACC_PUBLIC)
 	PHP_ME(domelement, remove, arginfo_dom_element_remove, ZEND_ACC_PUBLIC)
 	PHP_ME(domelement, append, arginfo_dom_element_append, ZEND_ACC_PUBLIC)
+	PHP_ME(domelement, prepend, arginfo_dom_element_prepend, ZEND_ACC_PUBLIC)
 	PHP_FE_END
 };
 /* }}} */
@@ -1336,7 +1340,7 @@ PHP_METHOD(domelement, remove)
 	php_dom_throw_error(NOT_FOUND_ERR, stricterror);
 	RETURN_NULL();
 }
-/* }}} end dom_node_remove_child */
+/* }}} end DOMElement::remove */
 
 /* {{{ proto void DOMElement::append();
 URL:
@@ -1358,4 +1362,32 @@ PHP_METHOD(domelement, append)
 
 	dom_parent_node_append(intern, args, argc);
 }
+/* }}} end DOMElement::append */
+
+/* {{{ proto void DOMElement::prepend();
+URL:
+Since:
+*/
+PHP_METHOD(domelement, prepend)
+{
+	int argc;
+	zval *args, *id;
+	dom_object *intern;
+	xmlNode *context;
+
+	if (zend_parse_parameters(ZEND_NUM_ARGS(), "+", &args, &argc) == FAILURE) {
+		return;
+	}
+
+	id = ZEND_THIS;
+	DOM_GET_OBJ(context, id, xmlNodePtr, intern);
+
+	if (context->children == NULL) {
+		dom_parent_node_append(intern, args, argc);
+	} else {
+		dom_parent_node_prepend(intern, args, argc);
+	}
+}
+/* }}} end DOMElement::prepend */
+
 #endif

--- a/ext/dom/element.c
+++ b/ext/dom/element.c
@@ -1294,10 +1294,10 @@ Since:
 */
 PHP_METHOD(domelement, remove)
 {
-	zval *id, *node;
+	zval *id;
 	xmlNodePtr children, child;
-	dom_object *intern, *childobj;
-	int ret, stricterror;
+	dom_object *intern;
+	int stricterror;
 
 	id = ZEND_THIS;
 	if (zend_parse_parameters_none() == FAILURE) {

--- a/ext/dom/element.c
+++ b/ext/dom/element.c
@@ -118,6 +118,9 @@ ZEND_END_ARG_INFO();
 
 ZEND_BEGIN_ARG_INFO_EX(arginfo_dom_element_remove, 0, 0, 0)
 ZEND_END_ARG_INFO();
+
+ZEND_BEGIN_ARG_INFO_EX(arginfo_dom_element_append, 0, 0, 0)
+ZEND_END_ARG_INFO();
 /* }}} */
 
 /*
@@ -148,6 +151,7 @@ const zend_function_entry php_dom_element_class_functions[] = { /* {{{ */
 	PHP_FALIAS(setIdAttributeNode, dom_element_set_id_attribute_node, arginfo_dom_element_set_id_attribute_node)
 	PHP_ME(domelement, __construct, arginfo_dom_element_construct, ZEND_ACC_PUBLIC)
 	PHP_ME(domelement, remove, arginfo_dom_element_remove, ZEND_ACC_PUBLIC)
+	PHP_ME(domelement, append, arginfo_dom_element_append, ZEND_ACC_PUBLIC)
 	PHP_FE_END
 };
 /* }}} */
@@ -1334,4 +1338,24 @@ PHP_METHOD(domelement, remove)
 }
 /* }}} end dom_node_remove_child */
 
+/* {{{ proto void DOMElement::append();
+URL:
+Since:
+*/
+PHP_METHOD(domelement, append)
+{
+	int argc;
+	zval *args, *id;
+	dom_object *intern;
+	xmlNode *context;
+
+	if (zend_parse_parameters(ZEND_NUM_ARGS(), "+", &args, &argc) == FAILURE) {
+		return;
+	}
+
+	id = ZEND_THIS;
+	DOM_GET_OBJ(context, id, xmlNodePtr, intern);
+
+	dom_parent_node_append(intern, args, argc);
+}
 #endif

--- a/ext/dom/node.c
+++ b/ext/dom/node.c
@@ -174,38 +174,6 @@ const zend_function_entry php_dom_child_node_class_functions[] = { /* {{{ */
 };
 /* }}} */
 
-static void dom_reconcile_ns(xmlDocPtr doc, xmlNodePtr nodep) /* {{{ */
-{
-	xmlNsPtr nsptr, nsdftptr, curns, prevns = NULL;
-
-	if (nodep->type == XML_ELEMENT_NODE) {
-		/* Following if block primarily used for inserting nodes created via createElementNS */
-		if (nodep->nsDef != NULL) {
-			curns = nodep->nsDef;
-			while (curns) {
-				nsdftptr = curns->next;
-				if (curns->href != NULL) {
-					if((nsptr = xmlSearchNsByHref(doc, nodep->parent, curns->href)) &&
-						(curns->prefix == NULL || xmlStrEqual(nsptr->prefix, curns->prefix))) {
-						curns->next = NULL;
-						if (prevns == NULL) {
-							nodep->nsDef = nsdftptr;
-						} else {
-							prevns->next = nsdftptr;
-						}
-						dom_set_old_ns(doc, curns);
-						curns = prevns;
-					}
-				}
-				prevns = curns;
-				curns = nsdftptr;
-			}
-		}
-		xmlReconciliateNs(doc, nodep);
-	}
-}
-/* }}} */
-
 /* {{{ nodeName	string
 readonly=yes
 URL: http://www.w3.org/TR/2003/WD-DOM-Level-3-Core-20030226/DOM3-Core.html#core-ID-F68D095

--- a/ext/dom/node.c
+++ b/ext/dom/node.c
@@ -124,6 +124,12 @@ ZEND_END_ARG_INFO();
 
 ZEND_BEGIN_ARG_INFO_EX(arginfo_dom_child_node_remove, 0, 0, 0)
 ZEND_END_ARG_INFO();
+
+ZEND_BEGIN_ARG_INFO_EX(arginfo_dom_child_node_after, 0, 0, 0)
+ZEND_END_ARG_INFO();
+
+ZEND_BEGIN_ARG_INFO_EX(arginfo_dom_child_node_before, 0, 0, 0)
+ZEND_END_ARG_INFO();
 /* }}} */
 
 /*
@@ -162,6 +168,8 @@ const zend_function_entry php_dom_node_class_functions[] = { /* {{{ */
 
 const zend_function_entry php_dom_child_node_class_functions[] = { /* {{{ */
 	PHP_ABSTRACT_ME(DOMChildNode, remove, arginfo_dom_child_node_remove)
+	PHP_ABSTRACT_ME(DOMChildNode, after, arginfo_dom_child_node_after)
+	PHP_ABSTRACT_ME(DOMChildNode, before, arginfo_dom_child_node_before)
 	PHP_FE_END
 };
 /* }}} */

--- a/ext/dom/node.c
+++ b/ext/dom/node.c
@@ -121,6 +121,9 @@ ZEND_BEGIN_ARG_INFO_EX(arginfo_dom_node_C14NFile, 0, 0, 1)
 	ZEND_ARG_ARRAY_INFO(0, xpath, 1)
 	ZEND_ARG_ARRAY_INFO(0, ns_prefixes, 1)
 ZEND_END_ARG_INFO();
+
+ZEND_BEGIN_ARG_INFO_EX(arginfo_dom_child_node_remove, 0, 0, 0)
+ZEND_END_ARG_INFO();
 /* }}} */
 
 /*
@@ -153,6 +156,12 @@ const zend_function_entry php_dom_node_class_functions[] = { /* {{{ */
 	PHP_ME(domnode, getLineNo, arginfo_dom_node_getLineNo, ZEND_ACC_PUBLIC)
 	PHP_ME(domnode, C14N, arginfo_dom_node_C14N, ZEND_ACC_PUBLIC)
 	PHP_ME(domnode, C14NFile, arginfo_dom_node_C14NFile, ZEND_ACC_PUBLIC)
+	PHP_FE_END
+};
+/* }}} */
+
+const zend_function_entry php_dom_child_node_class_functions[] = { /* {{{ */
+	PHP_ABSTRACT_ME(DOMChildNode, remove, arginfo_dom_child_node_remove)
 	PHP_FE_END
 };
 /* }}} */

--- a/ext/dom/node.c
+++ b/ext/dom/node.c
@@ -558,6 +558,72 @@ int dom_node_next_sibling_read(dom_object *obj, zval *retval)
 
 /* }}} */
 
+/* {{{ previousElementSibling	DomNode
+readonly=yes
+URL: http://www.w3.org/TR/2003/WD-DOM-Level-3-Core-20030226/DOM3-Core.html#core-ID-640FB3C8
+Since:
+*/
+int dom_node_previous_element_sibling_read(dom_object *obj, zval *retval)
+{
+	xmlNode *nodep, *prevsib;
+
+	nodep = dom_object_get_node(obj);
+
+	if (nodep == NULL) {
+		php_dom_throw_error(INVALID_STATE_ERR, 0);
+		return FAILURE;
+	}
+
+	prevsib = nodep->prev;
+
+	while (prevsib && prevsib->type != XML_ELEMENT_NODE) {
+		prevsib = prevsib->prev;
+	}
+
+	if (!prevsib) {
+		ZVAL_NULL(retval);
+		return SUCCESS;
+	}
+
+	php_dom_create_object(prevsib, retval, obj);
+	return SUCCESS;
+}
+
+/* }}} */
+
+/* {{{ nextElementSibling	DomNode
+readonly=yes
+URL: http://www.w3.org/TR/2003/WD-DOM-Level-3-Core-20030226/DOM3-Core.html#core-ID-6AC54C2F
+Since:
+*/
+int dom_node_next_element_sibling_read(dom_object *obj, zval *retval)
+{
+	xmlNode *nodep, *nextsib;
+
+	nodep = dom_object_get_node(obj);
+
+	if (nodep == NULL) {
+		php_dom_throw_error(INVALID_STATE_ERR, 0);
+		return FAILURE;
+	}
+
+	nextsib = nodep->next;
+
+	while (nextsib != NULL && nextsib->type != XML_ELEMENT_NODE) {
+		nextsib = nextsib->next;
+	}
+
+	if (!nextsib) {
+		ZVAL_NULL(retval);
+		return SUCCESS;
+	}
+
+	php_dom_create_object(nextsib, retval, obj);
+	return SUCCESS;
+}
+
+/* }}} */
+
 /* {{{ attributes	DomNamedNodeMap
 readonly=yes
 URL: http://www.w3.org/TR/2003/WD-DOM-Level-3-Core-20030226/DOM3-Core.html#core-ID-84CF096

--- a/ext/dom/node.c
+++ b/ext/dom/node.c
@@ -438,7 +438,6 @@ int dom_node_child_nodes_read(dom_object *obj, zval *retval)
 
 	return SUCCESS;
 }
-
 /* }}} */
 
 /* {{{ firstChild DomNode

--- a/ext/dom/parentnode.c
+++ b/ext/dom/parentnode.c
@@ -24,9 +24,20 @@
 #if HAVE_LIBXML && HAVE_DOM
 #include "php_dom.h"
 
+
+/* {{{ DOMParentNode methods */
+ZEND_BEGIN_ARG_INFO_EX(arginfo_dom_parentnode_append, 0, 0, 0)
+ZEND_END_ARG_INFO();
+
+ZEND_BEGIN_ARG_INFO_EX(arginfo_dom_parentnode_prepend, 0, 0, 0)
+ZEND_END_ARG_INFO();
+
 const zend_function_entry php_dom_parent_node_class_functions[] = { /* {{{ */
+	PHP_ABSTRACT_ME(DOMParentNode, append, arginfo_dom_parentnode_append)
+	PHP_ABSTRACT_ME(DOMParentNode, prepend, arginfo_dom_parentnode_prepend)
 	PHP_FE_END
 };
+/* }}} */
 
 /* {{{ firstElementChild DomParentNode
 readonly=yes

--- a/ext/dom/parentnode.c
+++ b/ext/dom/parentnode.c
@@ -209,7 +209,12 @@ void dom_parent_node_append(dom_object *context, zval *nodes, int nodesc)
 	prevsib = contextNode->last;
 
 	if (newchild) {
-		prevsib->next = newchild;
+		if (prevsib != NULL) {
+			prevsib->next = newchild;
+		} else {
+			contextNode->children = newchild;
+		}
+
 		newchild->prev = prevsib;
 		contextNode->last = fragment->last;
 
@@ -225,6 +230,8 @@ void dom_parent_node_append(dom_object *context, zval *nodes, int nodesc)
 
 		fragment->children = NULL;
 		fragment->last = NULL;
+
+		dom_reconcile_ns(contextNode->doc, newchild);
 	}
 }
 
@@ -256,6 +263,8 @@ void dom_parent_node_prepend(dom_object *context, zval *nodes, int nodesc)
 
 		fragment->children = NULL;
 		fragment->last = NULL;
+
+		dom_reconcile_ns(contextNode->doc, newchild);
 	}
 }
 
@@ -293,6 +302,8 @@ void dom_parent_node_after(dom_object *context, zval *nodes, int nodesc)
 
 		fragment->children = NULL;
 		fragment->last = NULL;
+
+		dom_reconcile_ns(prevsib->doc, newchild);
 	}
 }
 
@@ -325,6 +336,8 @@ void dom_parent_node_before(dom_object *context, zval *nodes, int nodesc)
 
 		fragment->children = NULL;
 		fragment->last = NULL;
+
+		dom_reconcile_ns(nextsib->doc, newchild);
 	}
 }
 

--- a/ext/dom/parentnode.c
+++ b/ext/dom/parentnode.c
@@ -1,0 +1,131 @@
+/*
+   +----------------------------------------------------------------------+
+   | PHP Version 7                                                        |
+   +----------------------------------------------------------------------+
+   | Copyright (c) The PHP Group                                          |
+   +----------------------------------------------------------------------+
+   | This source file is subject to version 3.01 of the PHP license,      |
+   | that is bundled with this package in the file LICENSE, and is        |
+   | available through the world-wide-web at the following url:           |
+   | http://www.php.net/license/3_01.txt                                  |
+   | If you did not receive a copy of the PHP license and are unable to   |
+   | obtain it through the world-wide-web, please send a note to          |
+   | license@php.net so we can mail you a copy immediately.               |
+   +----------------------------------------------------------------------+
+   | Authors: Benjamin Eberlei <beberlei@php.net>                         |
+   +----------------------------------------------------------------------+
+*/
+
+#ifdef HAVE_CONFIG_H
+#include "config.h"
+#endif
+
+#include "php.h"
+#if HAVE_LIBXML && HAVE_DOM
+#include "php_dom.h"
+
+const zend_function_entry php_dom_parent_node_class_functions[] = { /* {{{ */
+	PHP_FE_END
+};
+
+/* {{{ firstElementChild DomParentNode
+readonly=yes
+URL: https://www.w3.org/TR/dom/#dom-parentnode-firstelementchild
+*/
+int dom_parent_node_first_element_child_read(dom_object *obj, zval *retval)
+{
+	xmlNode *nodep, *first = NULL;
+
+	nodep = dom_object_get_node(obj);
+
+	if (nodep == NULL) {
+		php_dom_throw_error(INVALID_STATE_ERR, 0);
+		return FAILURE;
+	}
+
+	if (dom_node_children_valid(nodep) == SUCCESS) {
+		first = nodep->children;
+
+		while (first && first->type != XML_ELEMENT_NODE) {
+			first = first->next;
+		}
+	}
+
+	if (!first) {
+		ZVAL_NULL(retval);
+		return SUCCESS;
+	}
+
+	php_dom_create_object(first, retval, obj);
+	return SUCCESS;
+}
+/* }}} */
+
+/* {{{ lastElementChild DomParentNode
+readonly=yes
+URL: https://www.w3.org/TR/dom/#dom-parentnode-lastelementchild
+*/
+int dom_parent_node_last_element_child_read(dom_object *obj, zval *retval)
+{
+	xmlNode *nodep, *last = NULL;
+
+	nodep = dom_object_get_node(obj);
+
+	if (nodep == NULL) {
+		php_dom_throw_error(INVALID_STATE_ERR, 0);
+		return FAILURE;
+	}
+
+	if (dom_node_children_valid(nodep) == SUCCESS) {
+		last = nodep->last;
+
+		while (last && last->type != XML_ELEMENT_NODE) {
+			last = last->prev;
+		}
+	}
+
+	if (!last) {
+		ZVAL_NULL(retval);
+		return SUCCESS;
+	}
+
+	php_dom_create_object(last, retval, obj);
+	return SUCCESS;
+}
+/* }}} */
+
+/* {{{ childElementCount DomParentNode
+readonly=yes
+https://www.w3.org/TR/dom/#dom-parentnode-childelementcount
+*/
+int dom_parent_node_child_element_count(dom_object *obj, zval *retval)
+{
+	xmlNode *nodep, *first = NULL;
+	zend_long count = 0;
+
+	nodep = dom_object_get_node(obj);
+
+	if (nodep == NULL) {
+		php_dom_throw_error(INVALID_STATE_ERR, 0);
+		return FAILURE;
+	}
+
+	if (dom_node_children_valid(nodep) == SUCCESS) {
+		first = nodep->children;
+
+		while (first != NULL) {
+			if (first->type == XML_ELEMENT_NODE) {
+				count++;
+			}
+
+			first = first->next;
+		}
+	}
+
+	ZVAL_LONG(retval, count);
+
+	return SUCCESS;
+}
+/* }}} */
+
+#endif

--- a/ext/dom/parentnode.c
+++ b/ext/dom/parentnode.c
@@ -157,7 +157,7 @@ xmlNode* dom_zvals_to_fragment(dom_object *context, xmlNode *contextNode, zval *
 				xmlSetTreeDoc(newNode, documentNode);
 
 				if (!xmlAddChild(fragment, newNode)) {
-					return;
+					return NULL;
 				}
 
 				break;
@@ -177,7 +177,7 @@ xmlNode* dom_zvals_to_fragment(dom_object *context, xmlNode *contextNode, zval *
 					xmlSetTreeDoc(newNode, documentNode);
 
 					if (!xmlAddChild(fragment, newNode)) {
-						return;
+						return NULL;
 					}
 				}
 
@@ -201,6 +201,37 @@ void dom_parent_node_append(dom_object *context, zval *nodes, int nodesc)
 		prevsib->next = newchild;
 		newchild->prev = prevsib;
 		contextNode->last = fragment->last;
+
+		node = newchild;
+		while (node != NULL) {
+			node->parent = contextNode;
+
+			if (node == fragment->last) {
+				break;
+			}
+			node = node->next;
+		}
+
+		fragment->children = NULL;
+		fragment->last = NULL;
+	}
+}
+
+void dom_parent_node_prepend(dom_object *context, zval *nodes, int nodesc)
+{
+	xmlNode *contextNode = dom_object_get_node(context);
+	xmlNodePtr newchild, node, prevsib, nextsib;
+	xmlNode *fragment = dom_zvals_to_fragment(context, contextNode, nodes, nodesc);
+
+	newchild = fragment->children;
+	prevsib = NULL;
+	nextsib = contextNode->children;
+
+	if (newchild) {
+		contextNode->children = newchild;
+		newchild->prev = prevsib;
+		fragment->last->next = nextsib;
+		nextsib->prev = fragment->last;
 
 		node = newchild;
 		while (node != NULL) {

--- a/ext/dom/php_dom.c
+++ b/ext/dom/php_dom.c
@@ -82,6 +82,7 @@ static HashTable dom_domstringlist_prop_handlers;
 static HashTable dom_namelist_prop_handlers;
 static HashTable dom_domimplementationlist_prop_handlers;
 static HashTable dom_document_prop_handlers;
+static HashTable dom_documentfragment_prop_handlers;
 static HashTable dom_node_prop_handlers;
 static HashTable dom_nodelist_prop_handlers;
 static HashTable dom_namednodemap_prop_handlers;
@@ -677,7 +678,15 @@ PHP_MINIT_FUNCTION(dom)
 	zend_hash_add_ptr(&classes, ce.name, &dom_namespace_node_prop_handlers);
 
 	REGISTER_DOM_CLASS(ce, "DOMDocumentFragment", dom_node_class_entry, php_dom_documentfragment_class_functions, dom_documentfragment_class_entry);
-	zend_hash_add_ptr(&classes, ce.name, &dom_node_prop_handlers);
+	zend_hash_init(&dom_documentfragment_prop_handlers, 0, NULL, dom_dtor_prop_handler, 1);
+
+	dom_register_prop_handler(&dom_documentfragment_prop_handlers, "firstElementChild", sizeof("firstElementChild")-1, dom_parent_node_first_element_child_read, NULL);
+	dom_register_prop_handler(&dom_documentfragment_prop_handlers, "lastElementChild", sizeof("lastElementChild")-1, dom_parent_node_last_element_child_read, NULL);
+	dom_register_prop_handler(&dom_documentfragment_prop_handlers, "childElementCount", sizeof("childElementCount")-1, dom_parent_node_child_element_count, NULL);
+
+	zend_hash_merge(&dom_documentfragment_prop_handlers, &dom_node_prop_handlers, dom_copy_prop_handler, 0);
+	zend_hash_add_ptr(&classes, ce.name, &dom_documentfragment_prop_handlers);
+	zend_class_implements(dom_documentfragment_class_entry, 1, dom_parentnode_class_entry);
 
 	REGISTER_DOM_CLASS(ce, "DOMDocument", dom_node_class_entry, php_dom_document_class_functions, dom_document_class_entry);
 	zend_hash_init(&dom_document_prop_handlers, 0, NULL, dom_dtor_prop_handler, 1);
@@ -707,7 +716,6 @@ PHP_MINIT_FUNCTION(dom)
 
 	zend_hash_merge(&dom_document_prop_handlers, &dom_node_prop_handlers, dom_copy_prop_handler, 0);
 	zend_hash_add_ptr(&classes, ce.name, &dom_document_prop_handlers);
-
 	zend_class_implements(dom_document_class_entry, 1, dom_parentnode_class_entry);
 
 	INIT_CLASS_ENTRY(ce, "DOMNodeList", php_dom_nodelist_class_functions);
@@ -952,6 +960,7 @@ PHP_MSHUTDOWN_FUNCTION(dom) /* {{{ */
 	zend_hash_destroy(&dom_namelist_prop_handlers);
 	zend_hash_destroy(&dom_domimplementationlist_prop_handlers);
 	zend_hash_destroy(&dom_document_prop_handlers);
+	zend_hash_destroy(&dom_documentfragment_prop_handlers);
 	zend_hash_destroy(&dom_node_prop_handlers);
 	zend_hash_destroy(&dom_namespace_node_prop_handlers);
 	zend_hash_destroy(&dom_nodelist_prop_handlers);

--- a/ext/dom/php_dom.c
+++ b/ext/dom/php_dom.c
@@ -701,8 +701,14 @@ PHP_MINIT_FUNCTION(dom)
 	dom_register_prop_handler(&dom_document_prop_handlers, "recover", sizeof("recover")-1, dom_document_recover_read, dom_document_recover_write);
 	dom_register_prop_handler(&dom_document_prop_handlers, "substituteEntities", sizeof("substituteEntities")-1, dom_document_substitue_entities_read, dom_document_substitue_entities_write);
 
+	dom_register_prop_handler(&dom_document_prop_handlers, "firstElementChild", sizeof("firstElementChild")-1, dom_parent_node_first_element_child_read, NULL);
+	dom_register_prop_handler(&dom_document_prop_handlers, "lastElementChild", sizeof("lastElementChild")-1, dom_parent_node_last_element_child_read, NULL);
+	dom_register_prop_handler(&dom_document_prop_handlers, "childElementCount", sizeof("childElementCount")-1, dom_parent_node_child_element_count, NULL);
+
 	zend_hash_merge(&dom_document_prop_handlers, &dom_node_prop_handlers, dom_copy_prop_handler, 0);
 	zend_hash_add_ptr(&classes, ce.name, &dom_document_prop_handlers);
+
+	zend_class_implements(dom_document_class_entry, 1, dom_parentnode_class_entry);
 
 	INIT_CLASS_ENTRY(ce, "DOMNodeList", php_dom_nodelist_class_functions);
 	ce.create_object = dom_nnodemap_objects_new;

--- a/ext/dom/php_dom.c
+++ b/ext/dom/php_dom.c
@@ -655,6 +655,8 @@ PHP_MINIT_FUNCTION(dom)
 	dom_register_prop_handler(&dom_node_prop_handlers, "lastChild", sizeof("lastChild")-1, dom_node_last_child_read, NULL);
 	dom_register_prop_handler(&dom_node_prop_handlers, "previousSibling", sizeof("previousSibling")-1, dom_node_previous_sibling_read, NULL);
 	dom_register_prop_handler(&dom_node_prop_handlers, "nextSibling", sizeof("nextSibling")-1, dom_node_next_sibling_read, NULL);
+	dom_register_prop_handler(&dom_node_prop_handlers, "previousElementSibling", sizeof("previousElementSibling")-1, dom_node_previous_element_sibling_read, NULL);
+	dom_register_prop_handler(&dom_node_prop_handlers, "nextElementSibling", sizeof("nextElementSibling")-1, dom_node_next_element_sibling_read, NULL);
 	dom_register_prop_handler(&dom_node_prop_handlers, "attributes", sizeof("attributes")-1, dom_node_attributes_read, NULL);
 	dom_register_prop_handler(&dom_node_prop_handlers, "ownerDocument", sizeof("ownerDocument")-1, dom_node_owner_document_read, NULL);
 	dom_register_prop_handler(&dom_node_prop_handlers, "namespaceURI", sizeof("namespaceURI")-1, dom_node_namespace_uri_read, NULL);

--- a/ext/dom/php_dom.c
+++ b/ext/dom/php_dom.c
@@ -1464,6 +1464,38 @@ void dom_set_old_ns(xmlDoc *doc, xmlNs *ns) {
 }
 /* }}} end dom_set_old_ns */
 
+void dom_reconcile_ns(xmlDocPtr doc, xmlNodePtr nodep) /* {{{ */
+{
+	xmlNsPtr nsptr, nsdftptr, curns, prevns = NULL;
+
+	if (nodep->type == XML_ELEMENT_NODE) {
+		/* Following if block primarily used for inserting nodes created via createElementNS */
+		if (nodep->nsDef != NULL) {
+			curns = nodep->nsDef;
+			while (curns) {
+				nsdftptr = curns->next;
+				if (curns->href != NULL) {
+					if((nsptr = xmlSearchNsByHref(doc, nodep->parent, curns->href)) &&
+						(curns->prefix == NULL || xmlStrEqual(nsptr->prefix, curns->prefix))) {
+						curns->next = NULL;
+						if (prevns == NULL) {
+							nodep->nsDef = nsdftptr;
+						} else {
+							prevns->next = nsdftptr;
+						}
+						dom_set_old_ns(doc, curns);
+						curns = prevns;
+					}
+				}
+				prevns = curns;
+				curns = nsdftptr;
+			}
+		}
+		xmlReconciliateNs(doc, nodep);
+	}
+}
+/* }}} */
+
 /*
 http://www.w3.org/TR/2004/REC-DOM-Level-3-Core-20040407/core.html#ID-DocCrElNS
 

--- a/ext/dom/php_dom.c
+++ b/ext/dom/php_dom.c
@@ -752,6 +752,8 @@ PHP_MINIT_FUNCTION(dom)
 	zend_hash_merge(&dom_characterdata_prop_handlers, &dom_node_prop_handlers, dom_copy_prop_handler, 0);
 	zend_hash_add_ptr(&classes, ce.name, &dom_characterdata_prop_handlers);
 
+	zend_class_implements(dom_characterdata_class_entry, 1, dom_childnode_class_entry);
+
 	REGISTER_DOM_CLASS(ce, "DOMAttr", dom_node_class_entry, php_dom_attr_class_functions, dom_attr_class_entry);
 
 	zend_hash_init(&dom_attr_prop_handlers, 0, NULL, dom_dtor_prop_handler, 1);
@@ -774,8 +776,7 @@ PHP_MINIT_FUNCTION(dom)
 	zend_hash_merge(&dom_element_prop_handlers, &dom_node_prop_handlers, dom_copy_prop_handler, 0);
 	zend_hash_add_ptr(&classes, ce.name, &dom_element_prop_handlers);
 
-	zend_class_implements(dom_element_class_entry, 1, dom_parentnode_class_entry);
-	zend_class_implements(dom_element_class_entry, 1, dom_childnode_class_entry);
+	zend_class_implements(dom_element_class_entry, 2, dom_parentnode_class_entry, dom_childnode_class_entry);
 
 	REGISTER_DOM_CLASS(ce, "DOMText", dom_characterdata_class_entry, php_dom_text_class_functions, dom_text_class_entry);
 

--- a/ext/dom/php_dom.c
+++ b/ext/dom/php_dom.c
@@ -38,6 +38,7 @@ PHP_DOM_EXPORT zend_class_entry *dom_node_class_entry;
 PHP_DOM_EXPORT zend_class_entry *dom_domexception_class_entry;
 PHP_DOM_EXPORT zend_class_entry *dom_domstringlist_class_entry;
 PHP_DOM_EXPORT zend_class_entry *dom_namelist_class_entry;
+PHP_DOM_EXPORT zend_class_entry *dom_parentnode_class_entry;
 PHP_DOM_EXPORT zend_class_entry *dom_domimplementationlist_class_entry;
 PHP_DOM_EXPORT zend_class_entry *dom_domimplementationsource_class_entry;
 PHP_DOM_EXPORT zend_class_entry *dom_domimplementation_class_entry;
@@ -629,6 +630,9 @@ PHP_MINIT_FUNCTION(dom)
 	dom_register_prop_handler(&dom_namelist_prop_handlers, "length", sizeof("length")-1, dom_namelist_length_read, NULL);
 	zend_hash_add_ptr(&classes, ce.name, &dom_namelist_prop_handlers);
 
+	INIT_CLASS_ENTRY(ce, "DOMParentNode", php_dom_parent_node_class_functions);
+	dom_parentnode_class_entry = zend_register_internal_interface(&ce);
+
 	REGISTER_DOM_CLASS(ce, "DOMImplementationList", NULL, php_dom_domimplementationlist_class_functions, dom_domimplementationlist_class_entry);
 
 	zend_hash_init(&dom_domimplementationlist_prop_handlers, 0, NULL, dom_dtor_prop_handler, 1);
@@ -744,8 +748,13 @@ PHP_MINIT_FUNCTION(dom)
 	zend_hash_init(&dom_element_prop_handlers, 0, NULL, dom_dtor_prop_handler, 1);
 	dom_register_prop_handler(&dom_element_prop_handlers, "tagName", sizeof("tagName")-1, dom_element_tag_name_read, NULL);
 	dom_register_prop_handler(&dom_element_prop_handlers, "schemaTypeInfo", sizeof("schemaTypeInfo")-1, dom_element_schema_type_info_read, NULL);
+	dom_register_prop_handler(&dom_element_prop_handlers, "firstElementChild", sizeof("firstElementChild")-1, dom_parent_node_first_element_child_read, NULL);
+	dom_register_prop_handler(&dom_element_prop_handlers, "lastElementChild", sizeof("lastElementChild")-1, dom_parent_node_last_element_child_read, NULL);
+	dom_register_prop_handler(&dom_element_prop_handlers, "childElementCount", sizeof("childElementCount")-1, dom_parent_node_child_element_count, NULL);
 	zend_hash_merge(&dom_element_prop_handlers, &dom_node_prop_handlers, dom_copy_prop_handler, 0);
 	zend_hash_add_ptr(&classes, ce.name, &dom_element_prop_handlers);
+
+	zend_class_implements(dom_element_class_entry, 1, dom_parentnode_class_entry);
 
 	REGISTER_DOM_CLASS(ce, "DOMText", dom_characterdata_class_entry, php_dom_text_class_functions, dom_text_class_entry);
 

--- a/ext/dom/php_dom.c
+++ b/ext/dom/php_dom.c
@@ -39,6 +39,7 @@ PHP_DOM_EXPORT zend_class_entry *dom_domexception_class_entry;
 PHP_DOM_EXPORT zend_class_entry *dom_domstringlist_class_entry;
 PHP_DOM_EXPORT zend_class_entry *dom_namelist_class_entry;
 PHP_DOM_EXPORT zend_class_entry *dom_parentnode_class_entry;
+PHP_DOM_EXPORT zend_class_entry *dom_childnode_class_entry;
 PHP_DOM_EXPORT zend_class_entry *dom_domimplementationlist_class_entry;
 PHP_DOM_EXPORT zend_class_entry *dom_domimplementationsource_class_entry;
 PHP_DOM_EXPORT zend_class_entry *dom_domimplementation_class_entry;
@@ -634,6 +635,9 @@ PHP_MINIT_FUNCTION(dom)
 	INIT_CLASS_ENTRY(ce, "DOMParentNode", php_dom_parent_node_class_functions);
 	dom_parentnode_class_entry = zend_register_internal_interface(&ce);
 
+	INIT_CLASS_ENTRY(ce, "DOMChildNode", php_dom_child_node_class_functions);
+	dom_childnode_class_entry = zend_register_internal_interface(&ce);
+
 	REGISTER_DOM_CLASS(ce, "DOMImplementationList", NULL, php_dom_domimplementationlist_class_functions, dom_domimplementationlist_class_entry);
 
 	zend_hash_init(&dom_domimplementationlist_prop_handlers, 0, NULL, dom_dtor_prop_handler, 1);
@@ -771,6 +775,7 @@ PHP_MINIT_FUNCTION(dom)
 	zend_hash_add_ptr(&classes, ce.name, &dom_element_prop_handlers);
 
 	zend_class_implements(dom_element_class_entry, 1, dom_parentnode_class_entry);
+	zend_class_implements(dom_element_class_entry, 1, dom_childnode_class_entry);
 
 	REGISTER_DOM_CLASS(ce, "DOMText", dom_characterdata_class_entry, php_dom_text_class_functions, dom_text_class_entry);
 

--- a/ext/dom/php_dom.h
+++ b/ext/dom/php_dom.h
@@ -110,6 +110,7 @@ void node_list_unlink(xmlNodePtr node);
 int dom_check_qname(char *qname, char **localname, char **prefix, int uri_len, int name_len);
 xmlNsPtr dom_get_ns(xmlNodePtr node, char *uri, int *errorcode, char *prefix);
 void dom_set_old_ns(xmlDoc *doc, xmlNs *ns);
+void dom_reconcile_ns(xmlDocPtr doc, xmlNodePtr nodep);
 xmlNsPtr dom_get_nsdecl(xmlNode *node, xmlChar *localName);
 void dom_normalize (xmlNodePtr nodep);
 xmlNode *dom_get_elements_by_tag_name_ns_raw(xmlNodePtr nodep, char *ns, char *local, int *cur, int index);

--- a/ext/dom/php_dom.h
+++ b/ext/dom/php_dom.h
@@ -128,6 +128,9 @@ void dom_set_doc_classmap(php_libxml_ref_obj *document, zend_class_entry *basece
 zval *dom_nodelist_read_dimension(zval *object, zval *offset, int type, zval *rv);
 int dom_nodelist_has_dimension(zval *object, zval *member, int check_empty);
 
+void dom_parent_node_prepend(dom_object *context, zval *nodes, int nodesc);
+void dom_parent_node_append(dom_object *context, zval *nodes, int nodesc);
+
 #define REGISTER_DOM_CLASS(ce, name, parent_ce, funcs, entry) \
 INIT_CLASS_ENTRY(ce, name, funcs); \
 ce.create_object = dom_objects_new; \

--- a/ext/dom/php_dom.h
+++ b/ext/dom/php_dom.h
@@ -130,6 +130,8 @@ int dom_nodelist_has_dimension(zval *object, zval *member, int check_empty);
 
 void dom_parent_node_prepend(dom_object *context, zval *nodes, int nodesc);
 void dom_parent_node_append(dom_object *context, zval *nodes, int nodesc);
+void dom_parent_node_after(dom_object *context, zval *nodes, int nodesc);
+void dom_parent_node_before(dom_object *context, zval *nodes, int nodesc);
 
 #define REGISTER_DOM_CLASS(ce, name, parent_ce, funcs, entry) \
 INIT_CLASS_ENTRY(ce, name, funcs); \

--- a/ext/dom/tests/DOM4_DOMDocument_adoptNode.phpt
+++ b/ext/dom/tests/DOM4_DOMDocument_adoptNode.phpt
@@ -1,0 +1,50 @@
+--TEST--
+DOMDocumentNode::adoptNode()
+--SKIPIF--
+<?php require_once('skipif.inc'); ?>
+--FILE--
+<?php
+require_once("dom_test.inc");
+
+$source = new DOMDocument;
+$source->loadXML('<test><foo>content</foo></test>');
+if(!$source) {
+  echo "Error while parsing the document\n";
+  exit;
+}
+$target = new DOMDocument;
+$target->loadXML('<test><mark>first</mark></test>');
+if(!$target) {
+  echo "Error while parsing the document\n";
+  exit;
+}
+
+$element = $source->documentElement->firstChild;
+$adoptedElement = $target->adoptNode($element);
+
+if($adoptedElement !== $element || $element->ownerDocument !== $target) {
+  echo "Node was not adopted into target document\n";
+  exit;
+}
+
+$target->documentElement->appendChild($adoptedElement);
+
+print_node($target->documentElement->childNodes[0]);
+print_node($target->documentElement->childNodes[1]);
+print_node($source->documentElement);
+
+--EXPECT--
+Node Name: mark
+Node Type: 1
+Num Children: 1
+Node Content: first
+
+Node Name: foo
+Node Type: 1
+Num Children: 1
+Node Content: content
+
+Node Name: test
+Node Type: 1
+Num Children: 0
+Node Content:

--- a/ext/dom/tests/DOM4_DOMNode_ElementSiblings.phpt
+++ b/ext/dom/tests/DOM4_DOMNode_ElementSiblings.phpt
@@ -1,0 +1,28 @@
+--TEST--
+DOMNode: Element Siblings
+--SKIPIF--
+<?php require_once('skipif.inc'); ?>
+--FILE--
+<?php
+require_once("dom_test.inc");
+
+$dom = new DOMDocument;
+$dom->loadXML('<test>foo<bar>FirstElement</bar><bar>LastElement</bar>bar</test>');
+if(!$dom) {
+  echo "Error while parsing the document\n";
+  exit;
+}
+
+$element = $dom->documentElement;
+print_node($element->firstElementChild->nextElementSibling);
+print_node($element->lastElementChild->previousElementSibling);
+--EXPECT--
+Node Name: bar
+Node Type: 1
+Num Children: 1
+Node Content: LastElement
+
+Node Name: bar
+Node Type: 1
+Num Children: 1
+Node Content: FirstElement

--- a/ext/dom/tests/DOM4_DOMNode_after.phpt
+++ b/ext/dom/tests/DOM4_DOMNode_after.phpt
@@ -1,0 +1,38 @@
+--TEST--
+DOMNode::after()
+--SKIPIF--
+<?php require_once('skipif.inc'); ?>
+--FILE--
+<?php
+require_once("dom_test.inc");
+
+$dom = new DOMDocument;
+$dom->loadXML('<test><mark>first</mark></test>');
+if(!$dom) {
+  echo "Error while parsing the document\n";
+  exit;
+}
+
+$element = $dom->documentElement->firstChild;
+print_node($element);
+$element->after(
+  'text inserted after',
+  $dom->createElement('inserted-after', 'content')
+);
+print_node($dom->documentElement->childNodes[1]);
+print_node($dom->documentElement->childNodes[2]);
+--EXPECT--
+Node Name: mark
+Node Type: 1
+Num Children: 1
+Node Content: first
+
+Node Name: #text
+Node Type: 3
+Num Children: 0
+Node Content: text inserted after
+
+Node Name: inserted-after
+Node Type: 1
+Num Children: 1
+Node Content: content

--- a/ext/dom/tests/DOM4_DOMNode_after_adopts_node.phpt
+++ b/ext/dom/tests/DOM4_DOMNode_after_adopts_node.phpt
@@ -1,0 +1,49 @@
+--TEST--
+DOMNode::after() adopts node from other document
+--SKIPIF--
+<?php require_once('skipif.inc'); ?>
+--FILE--
+<?php
+require_once("dom_test.inc");
+
+$source = new DOMDocument;
+$source->loadXML('<test><foo>content</foo></test>');
+if(!$source) {
+  echo "Error while parsing the document\n";
+  exit;
+}
+$target = new DOMDocument;
+$target->loadXML('<test><mark>first</mark></test>');
+if(!$target) {
+  echo "Error while parsing the document\n";
+  exit;
+}
+
+$element = $source->documentElement->firstChild;
+$markElement = $target->documentElement->firstChild;
+$markElement->after($element);
+
+if($element->ownerDocument !== $target || $element !== $target->documentElement->childNodes[1]) {
+  echo "Node was not adopted into target document\n";
+  exit;
+}
+
+print_node($target->documentElement->childNodes[0]);
+print_node($target->documentElement->childNodes[1]);
+print_node($source->documentElement);
+
+--EXPECT--
+Node Name: mark
+Node Type: 1
+Num Children: 1
+Node Content: first
+
+Node Name: foo
+Node Type: 1
+Num Children: 1
+Node Content: content
+
+Node Name: test
+Node Type: 1
+Num Children: 0
+Node Content:

--- a/ext/dom/tests/DOM4_DOMNode_after_ns.phpt
+++ b/ext/dom/tests/DOM4_DOMNode_after_ns.phpt
@@ -1,0 +1,29 @@
+--TEST--
+DOMNode::after() with namespace
+--SKIPIF--
+<?php require_once('skipif.inc'); ?>
+--FILE--
+<?php
+require_once("dom_test.inc");
+
+$doc  = new DOMDocument('1.0', 'utf-8');
+$doc->formatOutput = true;
+
+$root = $doc->createElementNS('http://www.w3.org/2005/Atom', 'element');
+$doc->appendChild($root);
+$root->setAttributeNS('http://www.w3.org/2000/xmlns/' ,'xmlns:g', 'http://base.google.com/ns/1.0');
+
+$item = $doc->createElementNS('http://base.google.com/ns/1.0', 'g:item_type', 'house');
+$root->append($item);
+
+$item2 = $doc->createElementNS('http://base.google.com/ns/1.0', 'g:item_type', 'street');
+$item->after($item2);
+
+echo $doc->saveXML(), "\n";
+
+--EXPECT--
+<?xml version="1.0" encoding="utf-8"?>
+<element xmlns="http://www.w3.org/2005/Atom" xmlns:g="http://base.google.com/ns/1.0">
+  <g:item_type>house</g:item_type>
+  <g:item_type>street</g:item_type>
+</element>

--- a/ext/dom/tests/DOM4_DOMNode_append_ns.phpt
+++ b/ext/dom/tests/DOM4_DOMNode_append_ns.phpt
@@ -1,0 +1,25 @@
+--TEST--
+DOMNode::append() with namespace
+--SKIPIF--
+<?php require_once('skipif.inc'); ?>
+--FILE--
+<?php
+require_once("dom_test.inc");
+
+$doc  = new DOMDocument('1.0', 'utf-8');
+$doc->formatOutput = true;
+
+$root = $doc->createElementNS('http://www.w3.org/2005/Atom', 'element');
+$doc->appendChild($root);
+$root->setAttributeNS('http://www.w3.org/2000/xmlns/' ,'xmlns:g', 'http://base.google.com/ns/1.0');
+
+$item = $doc->createElementNS('http://base.google.com/ns/1.0', 'g:item_type', 'house');
+$root->append($item);
+
+echo $doc->saveXML(), "\n";
+
+--EXPECT--
+<?xml version="1.0" encoding="utf-8"?>
+<element xmlns="http://www.w3.org/2005/Atom" xmlns:g="http://base.google.com/ns/1.0">
+  <g:item_type>house</g:item_type>
+</element>

--- a/ext/dom/tests/DOM4_DOMNode_before.phpt
+++ b/ext/dom/tests/DOM4_DOMNode_before.phpt
@@ -1,0 +1,38 @@
+--TEST--
+DOMNode::before()
+--SKIPIF--
+<?php require_once('skipif.inc'); ?>
+--FILE--
+<?php
+require_once("dom_test.inc");
+
+$dom = new DOMDocument;
+$dom->loadXML('<test><mark>first</mark></test>');
+if(!$dom) {
+  echo "Error while parsing the document\n";
+  exit;
+}
+
+$element = $dom->documentElement->firstChild;
+print_node($element);
+$element->before(
+  $dom->createElement('inserted-before', 'content'),
+  'text inserted before'
+);
+print_node($dom->documentElement->childNodes[0]);
+print_node($dom->documentElement->childNodes[1]);
+--EXPECT--
+Node Name: mark
+Node Type: 1
+Num Children: 1
+Node Content: first
+
+Node Name: inserted-before
+Node Type: 1
+Num Children: 1
+Node Content: content
+
+Node Name: #text
+Node Type: 3
+Num Children: 0
+Node Content: text inserted before

--- a/ext/dom/tests/DOM4_DOMNode_before_ns.phpt
+++ b/ext/dom/tests/DOM4_DOMNode_before_ns.phpt
@@ -1,0 +1,29 @@
+--TEST--
+DOMNode::after() with namespace
+--SKIPIF--
+<?php require_once('skipif.inc'); ?>
+--FILE--
+<?php
+require_once("dom_test.inc");
+
+$doc  = new DOMDocument('1.0', 'utf-8');
+$doc->formatOutput = true;
+
+$root = $doc->createElementNS('http://www.w3.org/2005/Atom', 'element');
+$doc->appendChild($root);
+$root->setAttributeNS('http://www.w3.org/2000/xmlns/' ,'xmlns:g', 'http://base.google.com/ns/1.0');
+
+$item = $doc->createElementNS('http://base.google.com/ns/1.0', 'g:item_type', 'house');
+$root->append($item);
+
+$item2 = $doc->createElementNS('http://base.google.com/ns/1.0', 'g:item_type', 'street');
+$item->before($item2);
+
+echo $doc->saveXML(), "\n";
+
+--EXPECT--
+<?xml version="1.0" encoding="utf-8"?>
+<element xmlns="http://www.w3.org/2005/Atom" xmlns:g="http://base.google.com/ns/1.0">
+  <g:item_type>street</g:item_type>
+  <g:item_type>house</g:item_type>
+</element>

--- a/ext/dom/tests/DOM4_DOMNode_prepend_ns.phpt
+++ b/ext/dom/tests/DOM4_DOMNode_prepend_ns.phpt
@@ -1,0 +1,25 @@
+--TEST--
+DOMNode::prepend() with namespace
+--SKIPIF--
+<?php require_once('skipif.inc'); ?>
+--FILE--
+<?php
+require_once("dom_test.inc");
+
+$doc  = new DOMDocument('1.0', 'utf-8');
+$doc->formatOutput = true;
+
+$root = $doc->createElementNS('http://www.w3.org/2005/Atom', 'element');
+$doc->appendChild($root);
+$root->setAttributeNS('http://www.w3.org/2000/xmlns/' ,'xmlns:g', 'http://base.google.com/ns/1.0');
+
+$item = $doc->createElementNS('http://base.google.com/ns/1.0', 'g:item_type', 'house');
+$root->prepend($item);
+
+echo $doc->saveXML(), "\n";
+
+--EXPECT--
+<?xml version="1.0" encoding="utf-8"?>
+<element xmlns="http://www.w3.org/2005/Atom" xmlns:g="http://base.google.com/ns/1.0">
+  <g:item_type>house</g:item_type>
+</element>

--- a/ext/dom/tests/DOM4_DOMNode_remove.phpt
+++ b/ext/dom/tests/DOM4_DOMNode_remove.phpt
@@ -1,0 +1,33 @@
+--TEST--
+DOMNode::remove()
+--SKIPIF--
+<?php require_once('skipif.inc'); ?>
+--FILE--
+<?php
+require_once("dom_test.inc");
+
+$dom = new DOMDocument;
+$dom->loadXML('<test><one>first</one><two>second</two></test>');
+if(!$dom) {
+  echo "Error while parsing the document\n";
+  exit;
+}
+
+$element = $dom->documentElement;
+print_node($element->firstChild);
+$returnValue = $element->firstChild->remove();
+print_node($element->firstChild);
+var_dump($returnValue);
+--EXPECT--
+Node Name: one
+Node Type: 1
+Num Children: 1
+Node Content: first
+
+Node Name: two
+Node Type: 1
+Num Children: 1
+Node Content: second
+
+NULL
+

--- a/ext/dom/tests/DOM4_DOMNode_replaceWith.phpt
+++ b/ext/dom/tests/DOM4_DOMNode_replaceWith.phpt
@@ -1,0 +1,44 @@
+--TEST--
+DOMNode::replaceWith()
+--SKIPIF--
+<?php require_once('skipif.inc'); ?>
+--FILE--
+<?php
+require_once("dom_test.inc");
+
+$dom = new DOMDocument;
+$dom->loadXML('<test><mark>first</mark></test>');
+if(!$dom) {
+  echo "Error while parsing the document\n";
+  exit;
+}
+
+$element = $dom->documentElement->firstChild;
+print_node($dom->documentElement);
+$element->replaceWith(
+  $dom->createElement('element', 'content'),
+  'content'
+);
+
+print_node($dom->documentElement);
+print_node($dom->documentElement->childNodes[0]);
+print_node($dom->documentElement->childNodes[1]);
+--EXPECT--
+Node Name: test
+Node Type: 1
+Num Children: 1
+Node Content: first
+
+Node Name: test
+Node Type: 1
+Num Children: 2
+
+Node Name: element
+Node Type: 1
+Num Children: 1
+Node Content: content
+
+Node Name: #text
+Node Type: 3
+Num Children: 0
+Node Content: content

--- a/ext/dom/tests/DOM4_ParentNode.phpt
+++ b/ext/dom/tests/DOM4_ParentNode.phpt
@@ -13,6 +13,11 @@ if(!$dom) {
   exit;
 }
 
+var_dump($dom instanceof DOMParentNode);
+print_node($dom->firstElementChild);
+print_node($dom->lastElementChild);
+var_dump($dom->childElementCount);
+
 $element = $dom->documentElement;
 var_dump($element instanceof DOMParentNode);
 print_node($element->firstElementChild);
@@ -22,6 +27,16 @@ var_dump($element->lastElementChild->firstElementChild);
 var_dump($element->lastElementChild->lastElementChild);
 var_dump($element->lastElementChild->childElementCount);
 --EXPECT--
+bool(true)
+Node Name: test
+Node Type: 1
+Num Children: 4
+
+Node Name: test
+Node Type: 1
+Num Children: 4
+
+int(1)
 bool(true)
 Node Name: bar
 Node Type: 1

--- a/ext/dom/tests/DOM4_ParentNode.phpt
+++ b/ext/dom/tests/DOM4_ParentNode.phpt
@@ -1,0 +1,39 @@
+--TEST--
+DOMParentNode: Child Element Handling
+--SKIPIF--
+<?php require_once('skipif.inc'); ?>
+--FILE--
+<?php
+require_once("dom_test.inc");
+
+$dom = new DOMDocument;
+$dom->loadXML('<test>foo<bar>FirstElement</bar><bar>LastElement</bar>bar</test>');
+if(!$dom) {
+  echo "Error while parsing the document\n";
+  exit;
+}
+
+$element = $dom->documentElement;
+var_dump($element instanceof DOMParentNode);
+print_node($element->firstElementChild);
+print_node($element->lastElementChild);
+var_dump($element->childElementCount);
+var_dump($element->lastElementChild->firstElementChild);
+var_dump($element->lastElementChild->lastElementChild);
+var_dump($element->lastElementChild->childElementCount);
+--EXPECT--
+bool(true)
+Node Name: bar
+Node Type: 1
+Num Children: 1
+Node Content: FirstElement
+
+Node Name: bar
+Node Type: 1
+Num Children: 1
+Node Content: LastElement
+
+int(2)
+NULL
+NULL
+int(0)

--- a/ext/dom/tests/DOM4_ParentNode_Fragment.phpt
+++ b/ext/dom/tests/DOM4_ParentNode_Fragment.phpt
@@ -1,0 +1,44 @@
+--TEST--
+DOMParentNode: Child Element Handling
+--SKIPIF--
+<?php require_once('skipif.inc'); ?>
+--FILE--
+<?php
+require_once("dom_test.inc");
+
+$dom = new DOMDocument;
+$dom->loadXML('<test></test>');
+if(!$dom) {
+  echo "Error while parsing the document\n";
+  exit;
+}
+
+$fragment = $dom->createDocumentFragment();
+$fragment->appendChild($dom->createTextNode('foo'));
+$fragment->appendChild($dom->createElement('bar', 'FirstElement'));
+$fragment->appendChild($dom->createElement('bar', 'LastElement'));
+$fragment->appendChild($dom->createTextNode('bar'));
+
+var_dump($fragment instanceof DOMParentNode);
+print_node($fragment->firstElementChild);
+print_node($fragment->lastElementChild);
+var_dump($fragment->childElementCount);
+var_dump($fragment->lastElementChild->firstElementChild);
+var_dump($fragment->lastElementChild->lastElementChild);
+var_dump($fragment->lastElementChild->childElementCount);
+--EXPECT--
+bool(true)
+Node Name: bar
+Node Type: 1
+Num Children: 1
+Node Content: FirstElement
+
+Node Name: bar
+Node Type: 1
+Num Children: 1
+Node Content: LastElement
+
+int(2)
+NULL
+NULL
+int(0)

--- a/ext/dom/tests/DOM4_ParentNode_append.phpt
+++ b/ext/dom/tests/DOM4_ParentNode_append.phpt
@@ -19,7 +19,7 @@ $element->append(
   'content'
 );
 
-var_dump($dom->childElementCount);
+var_dump($dom->documentElement->childElementCount);
 print_node($element->childNodes[0]);
 print_node($element->childNodes[1]);
 print_node($element->childNodes[2]);
@@ -28,7 +28,7 @@ int(2)
 Node Name: mark
 Node Type: 1
 Num Children: 0
-Node Content:
+Node Content: 
 
 Node Name: element
 Node Type: 1

--- a/ext/dom/tests/DOM4_ParentNode_append.phpt
+++ b/ext/dom/tests/DOM4_ParentNode_append.phpt
@@ -19,10 +19,12 @@ $element->append(
   'content'
 );
 
+var_dump($dom->childElementCount);
 print_node($element->childNodes[0]);
 print_node($element->childNodes[1]);
 print_node($element->childNodes[2]);
 --EXPECT--
+int(2)
 Node Name: mark
 Node Type: 1
 Num Children: 0

--- a/ext/dom/tests/DOM4_ParentNode_append.phpt
+++ b/ext/dom/tests/DOM4_ParentNode_append.phpt
@@ -1,0 +1,39 @@
+--TEST--
+DOMParentNode::append()
+--SKIPIF--
+<?php require_once('skipif.inc'); ?>
+--FILE--
+<?php
+require_once("dom_test.inc");
+
+$dom = new DOMDocument;
+$dom->loadXML('<test><mark/></test>');
+if(!$dom) {
+  echo "Error while parsing the document\n";
+  exit;
+}
+
+$element = $dom->documentElement;
+$element->append(
+  $dom->createElement('element', 'content'),
+  'content'
+);
+
+print_node($element->childNodes[0]);
+print_node($element->childNodes[1]);
+print_node($element->childNodes[2]);
+--EXPECT--
+Node Name: mark
+Node Type: 1
+Num Children: 0
+Node Content:
+
+Node Name: element
+Node Type: 1
+Num Children: 1
+Node Content: content
+
+Node Name: #text
+Node Type: 3
+Num Children: 0
+Node Content: content

--- a/ext/dom/tests/DOM4_ParentNode_append_adopts_node.phpt
+++ b/ext/dom/tests/DOM4_ParentNode_append_adopts_node.phpt
@@ -1,0 +1,48 @@
+--TEST--
+DOMParentNode::append() adopts node from other document
+--SKIPIF--
+<?php require_once('skipif.inc'); ?>
+--FILE--
+<?php
+require_once("dom_test.inc");
+
+$source = new DOMDocument;
+$source->loadXML('<test><foo>content</foo></test>');
+if(!$source) {
+  echo "Error while parsing the document\n";
+  exit;
+}
+$target = new DOMDocument;
+$target->loadXML('<test><mark>first</mark></test>');
+if(!$target) {
+  echo "Error while parsing the document\n";
+  exit;
+}
+
+$element = $source->documentElement->firstChild;
+$target->documentElement->append($element);
+
+if($element->ownerDocument !== $target || $element !== $target->documentElement->childNodes[1]) {
+  echo "Node was not adopted into target document\n";
+  exit;
+}
+
+print_node($target->documentElement->childNodes[0]);
+print_node($target->documentElement->childNodes[1]);
+print_node($source->documentElement);
+
+--EXPECT--
+Node Name: mark
+Node Type: 1
+Num Children: 1
+Node Content: first
+
+Node Name: foo
+Node Type: 1
+Num Children: 1
+Node Content: content
+
+Node Name: test
+Node Type: 1
+Num Children: 0
+Node Content:

--- a/ext/dom/tests/DOM4_ParentNode_append_with_attributes.phpt
+++ b/ext/dom/tests/DOM4_ParentNode_append_with_attributes.phpt
@@ -1,0 +1,27 @@
+--TEST--
+DOMParentNode::append() with attributes
+--SKIPIF--
+<?php require_once('skipif.inc'); ?>
+--FILE--
+<?php
+require_once("dom_test.inc");
+
+$dom = new DOMDocument;
+$dom->loadXML('<test attr-one="21"/>');
+if(!$dom) {
+  echo "Error while parsing the document\n";
+  exit;
+}
+
+$replacement = $dom->createAttribute('attr-one');
+$replacement->value ='42';
+$addition = $dom->createAttribute('attr-two');
+$addition->value = '23';
+
+$element = $dom->documentElement;
+$element->append(
+  $replacement, $addition
+);
+echo $dom->saveXML($dom->documentElement);
+--EXPECT--
+<test attr-one="42" attr-two="23"/>

--- a/ext/dom/tests/DOM4_ParentNode_prepend.phpt
+++ b/ext/dom/tests/DOM4_ParentNode_prepend.phpt
@@ -1,0 +1,39 @@
+--TEST--
+DOMParentNode::prepend()
+--SKIPIF--
+<?php require_once('skipif.inc'); ?>
+--FILE--
+<?php
+require_once("dom_test.inc");
+
+$dom = new DOMDocument;
+$dom->loadXML('<test><mark/></test>');
+if(!$dom) {
+  echo "Error while parsing the document\n";
+  exit;
+}
+
+$element = $dom->documentElement;
+$element->prepend(
+  $dom->createElement('element', 'content'),
+  'content'
+);
+
+print_node($element->childNodes[0]);
+print_node($element->childNodes[1]);
+print_node($element->childNodes[2]);
+--EXPECT--
+Node Name: element
+Node Type: 1
+Num Children: 1
+Node Content: content
+
+Node Name: #text
+Node Type: 3
+Num Children: 0
+Node Content: content
+
+Node Name: mark
+Node Type: 1
+Num Children: 0
+Node Content:

--- a/ext/dom/tests/bug69846.phpt
+++ b/ext/dom/tests/bug69846.phpt
@@ -31,7 +31,7 @@ foreach ($dataNodes AS $node) {
 ===DONE===
 --EXPECTF--
 int(3)
-object(DOMText)#%d (19) {
+object(DOMText)#%d (21) {
   ["wholeText"]=>
   string(3) "
   "
@@ -59,6 +59,10 @@ object(DOMText)#%d (19) {
   NULL
   ["nextSibling"]=>
   NULL
+  ["previousElementSibling"]=>
+  NULL
+  ["nextElementSibling"]=>
+  NULL
   ["attributes"]=>
   NULL
   ["ownerDocument"]=>
@@ -75,7 +79,7 @@ object(DOMText)#%d (19) {
   string(3) "
   "
 }
-object(DOMElement)#%d (21) {
+object(DOMElement)#%d (23) {
   ["tagName"]=>
   string(5) "form1"
   ["schemaTypeInfo"]=>
@@ -108,6 +112,10 @@ object(DOMElement)#%d (21) {
   NULL
   ["nextSibling"]=>
   NULL
+  ["previousElementSibling"]=>
+  NULL
+  ["nextElementSibling"]=>
+  NULL
   ["attributes"]=>
   string(22) "(object value omitted)"
   ["ownerDocument"]=>
@@ -127,7 +135,7 @@ object(DOMElement)#%d (21) {
     Value C
   "
 }
-object(DOMText)#%d (19) {
+object(DOMText)#%d (21) {
   ["wholeText"]=>
   string(1) "
 "
@@ -154,6 +162,10 @@ object(DOMText)#%d (19) {
   ["previousSibling"]=>
   NULL
   ["nextSibling"]=>
+  NULL
+  ["previousElementSibling"]=>
+  NULL
+  ["nextElementSibling"]=>
   NULL
   ["attributes"]=>
   NULL

--- a/ext/dom/tests/bug69846.phpt
+++ b/ext/dom/tests/bug69846.phpt
@@ -75,11 +75,17 @@ object(DOMText)#%d (19) {
   string(3) "
   "
 }
-object(DOMElement)#%d (18) {
+object(DOMElement)#%d (21) {
   ["tagName"]=>
   string(5) "form1"
   ["schemaTypeInfo"]=>
   NULL
+  ["firstElementChild"]=>
+  string(22) "(object value omitted)"
+  ["lastElementChild"]=>
+  string(22) "(object value omitted)"
+  ["childElementCount"]=>
+  int(3)
   ["nodeName"]=>
   string(5) "form1"
   ["nodeValue"]=>

--- a/ext/dom/tests/domobject_debug_handler.phpt
+++ b/ext/dom/tests/domobject_debug_handler.phpt
@@ -51,6 +51,8 @@ DOMDocument Object
     [lastChild] => (object value omitted)
     [previousSibling] => 
     [nextSibling] => 
+    [previousElementSibling] => 
+    [nextElementSibling] => 
     [attributes] => 
     [ownerDocument] => 
     [namespaceURI] => 

--- a/ext/dom/tests/domobject_debug_handler.phpt
+++ b/ext/dom/tests/domobject_debug_handler.phpt
@@ -39,6 +39,9 @@ DOMDocument Object
     [preserveWhiteSpace] => 1
     [recover] => 
     [substituteEntities] => 
+    [firstElementChild] => (object value omitted)
+    [lastElementChild] => (object value omitted)
+    [childElementCount] => 1
     [nodeName] => #document
     [nodeValue] => 
     [nodeType] => 9


### PR DESCRIPTION
RFC: https://wiki.php.net/rfc/dom_living_standard_api

**NOTICE: This code still has a lot of duplication that we intend to cleanup and missing more tests.**

Add https://dom.spec.whatwg.org/ (formerly https://www.w3.org/TR/dom) specification to ext/dom

### DOMParentNode

- [x] Add `DOMParentNode` interface
- [x] Implement `firstElementChild`, `lastElementChild`, `childElementCount` property handlers
- [x] `DOMElement instanceof DOMParentNode`
- [x] `DOMDocument instanceof DOMParentNode`
- [x] `DOMFragment instanceof DOMParentNode`
- [x] Implement `prepend()`
- [x] Implement `append()`

We leave out  `DOMParentNode#querySelector` and `querySelectorAll` and leave open to include them in a new interface later. In any case translating CSS Selectors to XPath should be a userland concern, [Symfony CSS Selector](https://github.com/symfony/css-selector) and [FluentDOM PhpCSS](https://github.com/ThomasWeinert/PhpCss) are good examples.

### DOMNonDocumentTypeChildNode

Added `previousElementSibling`, `nextElementSibling` property handlers directly on `DOMChildNode` instead of introducing this extra interface. The reason is that for `DOMDocumentType#previousElementSibling` and `nextElementSibling` can just return `NULL`.

- [ ] Move properties to `DOMElement` and `DOMCharacterData`

### DOMChildNode

- [x] Add `DOMChildNode` interface
- [x] `DOMElement instanceof DOMChildNode`
- [x] `DOMCharacterData instanceof DOMChildNode`
- [ ] `DOMDocumentType instanceof DOMChildNode`
- [x] Implement `remove()`
- [x] Implement `before()`
- [x] Implement `after()`
- [ ] Implement `replaceWith()`

### DOMDocument

- [ ] `DOMDocument::adoptNode()`

### Implementation Todos

- [ ] Refactor existing `_php_dom_insert_fragment` to be reusable for all `append`, `prepend`, `before`, `after` methods instead of code duplication used now.
- [ ] Reduce duplication in PHP_METHOD implementations of `append`, `prepend`, `before`, `after`
- [ ] Add much more tests.
- [x] Add Reconcile Namespaces behavior
- [ ] Add relevant error handling for edge cases (read only, hierachy errors, ...)

### Testing

```
git clone git@github.com:php/php-src.git
cd php-src
git remote add beberlei git@github.com:beberlei/php-src.git
git fetch beberlei
git checkout -bDomLevel4 beberlei/DomLevel4
./buildconf
./configure  --prefix=/opt/php/php-src --disable-all --with-zlib --enable-xml --enable-libxml --enable-dom --enable-debug
make -j4
TESTS=ext/dom/tests/*.phpt make test
```