### PR TITLE
[Opcache] Add Opcache\Jit attribute example

### DIFF
--- a/Zend/tests/attributes/001_placement.phpt
+++ b/Zend/tests/attributes/001_placement.phpt
@@ -1,0 +1,112 @@
+--TEST--
+Attributes can be placed on all supported elements.
+--FILE--
+<?php
+
+<<A1(1)>>
+class Foo
+{
+    <<A1(2)>>
+    public const FOO = 'foo', BAR = 'bar';
+    
+    <<A1(3)>>
+    public $x, $y;
+    
+    <<A1(4)>>
+    public function foo(<<A1(5)>> $a, <<A1(6)>> $b) { }
+}
+
+$object = new <<A1(7)>> class () { };
+
+<<A1(8)>>
+function f1() { }
+
+$f2 = <<A1(9)>> function () { };
+
+$f3 = <<A1(10)>> fn () => 1;
+
+$ref = new \ReflectionClass(Foo::class);
+
+$sources = [
+    $ref,
+    $ref->getReflectionConstant('FOO'),
+    $ref->getReflectionConstant('BAR'),
+    $ref->getProperty('x'),
+    $ref->getProperty('y'),
+    $ref->getMethod('foo'),
+    $ref->getMethod('foo')->getParameters()[0],
+    $ref->getMethod('foo')->getParameters()[1],
+    new \ReflectionObject($object),
+    new \ReflectionFunction('f1'),
+    new \ReflectionFunction($f2),
+    new \ReflectionFunction($f3)
+];
+
+foreach ($sources as $r) {
+    foreach ($r->getAttributes() as $attr) {
+        var_dump($attr->getName(), $attr->getArguments());
+    }
+}
+
+?>
+--EXPECT--
+string(2) "A1"
+array(1) {
+  [0]=>
+  int(1)
+}
+string(2) "A1"
+array(1) {
+  [0]=>
+  int(2)
+}
+string(2) "A1"
+array(1) {
+  [0]=>
+  int(2)
+}
+string(2) "A1"
+array(1) {
+  [0]=>
+  int(3)
+}
+string(2) "A1"
+array(1) {
+  [0]=>
+  int(3)
+}
+string(2) "A1"
+array(1) {
+  [0]=>
+  int(4)
+}
+string(2) "A1"
+array(1) {
+  [0]=>
+  int(5)
+}
+string(2) "A1"
+array(1) {
+  [0]=>
+  int(6)
+}
+string(2) "A1"
+array(1) {
+  [0]=>
+  int(7)
+}
+string(2) "A1"
+array(1) {
+  [0]=>
+  int(8)
+}
+string(2) "A1"
+array(1) {
+  [0]=>
+  int(9)
+}
+string(2) "A1"
+array(1) {
+  [0]=>
+  int(10)
+}

--- a/Zend/tests/attributes/001_placement.phpt
+++ b/Zend/tests/attributes/001_placement.phpt
@@ -43,68 +43,83 @@ $sources = [
 ];
 
 foreach ($sources as $r) {
-    foreach ($r->getAttributes() as $attr) {
-        var_dump($attr->getName(), $attr->getArguments());
+	$attr = $r->getAttributes();
+	var_dump(count($attr));
+	
+    foreach ($attr as $a) {
+        var_dump($a->getName(), $a->getArguments());
     }
 }
 
 ?>
 --EXPECT--
+int(1)
 string(2) "A1"
 array(1) {
   [0]=>
   int(1)
 }
+int(1)
 string(2) "A1"
 array(1) {
   [0]=>
   int(2)
 }
+int(1)
 string(2) "A1"
 array(1) {
   [0]=>
   int(2)
 }
+int(1)
 string(2) "A1"
 array(1) {
   [0]=>
   int(3)
 }
+int(1)
 string(2) "A1"
 array(1) {
   [0]=>
   int(3)
 }
+int(1)
 string(2) "A1"
 array(1) {
   [0]=>
   int(4)
 }
+int(1)
 string(2) "A1"
 array(1) {
   [0]=>
   int(5)
 }
+int(1)
 string(2) "A1"
 array(1) {
   [0]=>
   int(6)
 }
+int(1)
 string(2) "A1"
 array(1) {
   [0]=>
   int(7)
 }
+int(1)
 string(2) "A1"
 array(1) {
   [0]=>
   int(8)
 }
+int(1)
 string(2) "A1"
 array(1) {
   [0]=>
   int(9)
 }
+int(1)
 string(2) "A1"
 array(1) {
   [0]=>

--- a/Zend/tests/attributes/002_rfcexample.phpt
+++ b/Zend/tests/attributes/002_rfcexample.phpt
@@ -28,7 +28,7 @@ namespace {
 
     var_dump($attributes[0]->getName());
     var_dump($attributes[0]->getArguments());
-    var_dump($attributes[0]->getAsObject());
+    var_dump($attributes[0]->newInstance());
 }
 --EXPECTF--
 string(28) "My\Attributes\SingleArgument"

--- a/Zend/tests/attributes/002_rfcexample.phpt
+++ b/Zend/tests/attributes/002_rfcexample.phpt
@@ -1,0 +1,41 @@
+--TEST--
+Attributes: RFC Example
+--FILE--
+<?php
+namespace My\Attributes {
+    use PhpAttribute;
+
+    <<PhpAttribute>>
+    class SingleArgument {
+        public $argumentValue;
+
+        public function __construct($argumentValue) {
+             $this->argumentValue = $argumentValue;
+        }
+    }
+}
+
+namespace {
+    use My\Attributes\SingleArgument;
+
+    <<SingleArgument("Hello World")>>
+    class Foo {
+    }
+
+    $reflectionClass = new \ReflectionClass(Foo::class);
+    $attributes = $reflectionClass->getAttributes();
+
+    var_dump($attributes[0]->getName());
+    var_dump($attributes[0]->getArguments());
+    var_dump($attributes[0]->getAsObject());
+}
+--EXPECTF--
+string(28) "My\Attributes\SingleArgument"
+array(1) {
+  [0]=>
+  string(11) "Hello World"
+}
+object(My\Attributes\SingleArgument)#3 (1) {
+  ["argumentValue"]=>
+  string(11) "Hello World"
+}

--- a/Zend/tests/attributes/002_rfcexample.phpt
+++ b/Zend/tests/attributes/002_rfcexample.phpt
@@ -1,7 +1,8 @@
 --TEST--
-Attributes: RFC Example
+Attributes: Example from Attributes RFC
 --FILE--
 <?php
+// https://wiki.php.net/rfc/attributes_v2#attribute_syntax
 namespace My\Attributes {
     use PhpAttribute;
 

--- a/Zend/tests/attributes/002_rfcexample.phpt
+++ b/Zend/tests/attributes/002_rfcexample.phpt
@@ -30,6 +30,7 @@ namespace {
     var_dump($attributes[0]->getArguments());
     var_dump($attributes[0]->newInstance());
 }
+?>
 --EXPECTF--
 string(28) "My\Attributes\SingleArgument"
 array(1) {

--- a/Zend/tests/attributes/003_ast_nodes.phpt
+++ b/Zend/tests/attributes/003_ast_nodes.phpt
@@ -50,10 +50,36 @@ var_dump(count($args));
 var_dump($args[0] === 'foo');
 var_dump($args[1] === C1::BAR);
 
+echo "\n";
+
 <<ExampleWithShift(4 >> 1)>>
 class C4 {}
 $ref = new \ReflectionClass(C4::class);
 var_dump($ref->getAttributes()[0]->getArguments());
+
+echo "\n";
+
+<<PhpAttribute>>
+class C5
+{
+	public function __construct() { }
+}
+
+$ref = new \ReflectionFunction(<<C5(MissingClass::SOME_CONST)>> function () { });
+$attr = $ref->getAttributes();
+var_dump(count($attr));
+
+try {
+	$attr[0]->getArguments();
+} catch (\Error $e) {
+	var_dump($e->getMessage());
+}
+
+try {
+	$attr[0]->newInstance();
+} catch (\Error $e) {
+	var_dump($e->getMessage());
+}
 
 ?>
 --EXPECT--
@@ -71,7 +97,13 @@ int(1)
 int(2)
 bool(true)
 bool(true)
+
 array(1) {
   [0]=>
   int(2)
 }
+
+int(1)
+string(30) "Class 'MissingClass' not found"
+string(30) "Class 'MissingClass' not found"
+

--- a/Zend/tests/attributes/003_ast_nodes.phpt
+++ b/Zend/tests/attributes/003_ast_nodes.phpt
@@ -50,6 +50,11 @@ var_dump(count($args));
 var_dump($args[0] === 'foo');
 var_dump($args[1] === C1::BAR);
 
+<<ExampleWithShift(4 >> 1)>>
+class C4 {}
+$ref = new \ReflectionClass(C4::class);
+var_dump($ref->getAttributes()[0]->getArguments());
+
 ?>
 --EXPECT--
 int(1)
@@ -66,3 +71,7 @@ int(1)
 int(2)
 bool(true)
 bool(true)
+array(1) {
+  [0]=>
+  int(2)
+}

--- a/Zend/tests/attributes/003_ast_nodes.phpt
+++ b/Zend/tests/attributes/003_ast_nodes.phpt
@@ -1,0 +1,68 @@
+--TEST--
+Attributes can deal with AST nodes.
+--FILE--
+<?php
+
+define('V1', strtoupper(php_sapi_name()));
+
+<<A1([V1 => V1])>>
+class C1
+{
+	public const BAR = 'bar';
+}
+
+$ref = new \ReflectionClass(C1::class);
+$attr = $ref->getAttributes();
+var_dump(count($attr));
+
+$args = $attr[0]->getArguments();
+var_dump(count($args), $args[0][V1] === V1);
+
+echo "\n";
+
+<<A1(V1, 1 + 2, C1::class)>>
+class C2 { }
+
+$ref = new \ReflectionClass(C2::class);
+$attr = $ref->getAttributes();
+var_dump(count($attr));
+
+$args = $attr[0]->getArguments();
+var_dump(count($args));
+var_dump($args[0] === V1);
+var_dump($args[1] === 3);
+var_dump($args[2] === C1::class);
+
+echo "\n";
+
+<<A1(self::FOO, C1::BAR)>>
+class C3
+{
+	private const FOO = 'foo';
+}
+
+$ref = new \ReflectionClass(C3::class);
+$attr = $ref->getAttributes();
+var_dump(count($attr));
+
+$args = $attr[0]->getArguments();
+var_dump(count($args));
+var_dump($args[0] === 'foo');
+var_dump($args[1] === C1::BAR);
+
+?>
+--EXPECT--
+int(1)
+int(1)
+bool(true)
+
+int(1)
+int(3)
+bool(true)
+bool(true)
+bool(true)
+
+int(1)
+int(2)
+bool(true)
+bool(true)

--- a/Zend/tests/attributes/004_name_resolution.phpt
+++ b/Zend/tests/attributes/004_name_resolution.phpt
@@ -1,0 +1,39 @@
+--TEST--
+Resolve attribute names
+--FILE--
+<?php
+function dump_attributes($attributes) {
+    $arr = [];
+    foreach ($attributes as $attribute) {
+        $arr[$attribute->getName()] = $attribute->getArguments();
+    }
+    var_dump($arr);
+}
+
+namespace Doctrine\ORM\Mapping {
+    class Entity {
+    }
+}
+
+namespace Foo {
+    use Doctrine\ORM\Mapping\Entity;
+
+    <<Entity(["foo" => "bar"])>>
+    function foo() {
+    }
+}
+
+namespace {
+    dump_attributes((new ReflectionFunction('Foo\foo'))->getAttributes());
+}
+--EXPECTF--
+array(1) {
+  ["Doctrine\ORM\Mapping\Entity"]=>
+  array(1) {
+    [0]=>
+    array(1) {
+      ["foo"]=>
+      string(3) "bar"
+    }
+  }
+}

--- a/Zend/tests/attributes/004_name_resolution.phpt
+++ b/Zend/tests/attributes/004_name_resolution.phpt
@@ -26,6 +26,7 @@ namespace Foo {
 namespace {
     dump_attributes((new ReflectionFunction('Foo\foo'))->getAttributes());
 }
+?>
 --EXPECTF--
 array(1) {
   ["Doctrine\ORM\Mapping\Entity"]=>

--- a/Zend/tests/attributes/004_name_resolution.phpt
+++ b/Zend/tests/attributes/004_name_resolution.phpt
@@ -5,7 +5,7 @@ Resolve attribute names
 function dump_attributes($attributes) {
     $arr = [];
     foreach ($attributes as $attribute) {
-        $arr[$attribute->getName()] = $attribute->getArguments();
+        $arr[] = ['name' => $attribute->getName(), 'args' => $attribute->getArguments()];
     }
     var_dump($arr);
 }
@@ -17,24 +17,62 @@ namespace Doctrine\ORM\Mapping {
 
 namespace Foo {
     use Doctrine\ORM\Mapping\Entity;
+    use Doctrine\ORM\Mapping as ORM;
 
-    <<Entity(["foo" => "bar"])>>
+    <<Entity("imported class")>>
+    <<ORM\Entity("imported namespace")>>
+    <<\Doctrine\ORM\Mapping\Entity("absolute from namespace")>>
+    <<\Entity("import absolute from global")>>
     function foo() {
     }
 }
 
 namespace {
+    class Entity {}
+
     dump_attributes((new ReflectionFunction('Foo\foo'))->getAttributes());
 }
 ?>
 --EXPECTF--
-array(1) {
-  ["Doctrine\ORM\Mapping\Entity"]=>
-  array(1) {
-    [0]=>
+array(4) {
+  [0]=>
+  array(2) {
+    ["name"]=>
+    string(27) "Doctrine\ORM\Mapping\Entity"
+    ["args"]=>
     array(1) {
-      ["foo"]=>
-      string(3) "bar"
+      [0]=>
+      string(14) "imported class"
+    }
+  }
+  [1]=>
+  array(2) {
+    ["name"]=>
+    string(27) "Doctrine\ORM\Mapping\Entity"
+    ["args"]=>
+    array(1) {
+      [0]=>
+      string(18) "imported namespace"
+    }
+  }
+  [2]=>
+  array(2) {
+    ["name"]=>
+    string(27) "Doctrine\ORM\Mapping\Entity"
+    ["args"]=>
+    array(1) {
+      [0]=>
+      string(23) "absolute from namespace"
+    }
+  }
+  [3]=>
+  array(2) {
+    ["name"]=>
+    string(6) "Entity"
+    ["args"]=>
+    array(1) {
+      [0]=>
+      string(27) "import absolute from global"
     }
   }
 }

--- a/Zend/tests/attributes/005_objects.phpt
+++ b/Zend/tests/attributes/005_objects.phpt
@@ -3,6 +3,7 @@ Attributes can be converted into objects.
 --FILE--
 <?php
 
+<<PhpAttribute>>
 class A1
 {
 	public string $name;
@@ -55,6 +56,7 @@ try {
 
 echo "\n";
 
+<<PhpAttribute>>
 class A3
 {
 	private function __construct() { }
@@ -70,6 +72,7 @@ try {
 
 echo "\n";
 
+<<PhpAttribute>>
 class A4 { }
 
 $ref = new \ReflectionFunction(<<A4(1)>> function () { });
@@ -78,6 +81,18 @@ try {
 	$ref->getAttributes()[0]->newInstance();
 } catch (\Error $e) {
 	var_dump('ERROR 5', $e->getMessage());
+}
+
+echo "\n";
+
+class A5 { }
+
+$ref = new \ReflectionFunction(<<A5>> function () { });
+
+try {
+	$ref->getAttributes()[0]->newInstance();
+} catch (\Error $e) {
+	var_dump('ERROR 6', $e->getMessage());
 }
 
 ?>
@@ -100,3 +115,6 @@ string(50) "Attribute constructor of class 'A3' must be public"
 
 string(7) "ERROR 5"
 string(71) "Attribute class 'A4' does not have a constructor, cannot pass arguments"
+
+string(7) "ERROR 6"
+string(78) "Attempting to use class 'A5' as attribute that does not have <<PhpAttribute>>."

--- a/Zend/tests/attributes/005_objects.phpt
+++ b/Zend/tests/attributes/005_objects.phpt
@@ -18,8 +18,8 @@ class A1
 $ref = new \ReflectionFunction(<<A1('test')>> function () { });
 
 foreach ($ref->getAttributes() as $attr) {
-	$obj = $attr->getAsObject();
-	
+	$obj = $attr->newInstance();
+
 	var_dump(get_class($obj), $obj->name, $obj->ttl);
 }
 
@@ -28,7 +28,7 @@ echo "\n";
 $ref = new \ReflectionFunction(<<A1>> function () { });
 
 try {
-	$ref->getAttributes()[0]->getAsObject();
+	$ref->getAttributes()[0]->newInstance();
 } catch (\ArgumentCountError $e) {
 	var_dump('ERROR 1', $e->getMessage());
 }
@@ -38,7 +38,7 @@ echo "\n";
 $ref = new \ReflectionFunction(<<A1([])>> function () { });
 
 try {
-	$ref->getAttributes()[0]->getAsObject();
+	$ref->getAttributes()[0]->newInstance();
 } catch (\TypeError $e) {
 	var_dump('ERROR 2', $e->getMessage());
 }
@@ -48,7 +48,7 @@ echo "\n";
 $ref = new \ReflectionFunction(<<A2>> function () { });
 
 try {
-	$ref->getAttributes()[0]->getAsObject();
+	$ref->getAttributes()[0]->newInstance();
 } catch (\Error $e) {
 	var_dump('ERROR 3', $e->getMessage());
 }
@@ -63,7 +63,7 @@ class A3
 $ref = new \ReflectionFunction(<<A3>> function () { });
 
 try {
-	$ref->getAttributes()[0]->getAsObject();
+	$ref->getAttributes()[0]->newInstance();
 } catch (\Error $e) {
 	var_dump('ERROR 4', $e->getMessage());
 }
@@ -75,7 +75,7 @@ class A4 { }
 $ref = new \ReflectionFunction(<<A4(1)>> function () { });
 
 try {
-	$ref->getAttributes()[0]->getAsObject();
+	$ref->getAttributes()[0]->newInstance();
 } catch (\Error $e) {
 	var_dump('ERROR 5', $e->getMessage());
 }

--- a/Zend/tests/attributes/005_objects.phpt
+++ b/Zend/tests/attributes/005_objects.phpt
@@ -1,0 +1,102 @@
+--TEST--
+Attributes can be converted into objects.
+--FILE--
+<?php
+
+class A1
+{
+	public string $name;
+	public int $ttl;
+
+	public function __construct(string $name, int $ttl = 50)
+	{
+		$this->name = $name;
+		$this->ttl = $ttl;
+	}
+}
+
+$ref = new \ReflectionFunction(<<A1('test')>> function () { });
+
+foreach ($ref->getAttributes() as $attr) {
+	$obj = $attr->getAsObject();
+	
+	var_dump(get_class($obj), $obj->name, $obj->ttl);
+}
+
+echo "\n";
+
+$ref = new \ReflectionFunction(<<A1>> function () { });
+
+try {
+	$ref->getAttributes()[0]->getAsObject();
+} catch (\ArgumentCountError $e) {
+	var_dump('ERROR 1', $e->getMessage());
+}
+
+echo "\n";
+
+$ref = new \ReflectionFunction(<<A1([])>> function () { });
+
+try {
+	$ref->getAttributes()[0]->getAsObject();
+} catch (\TypeError $e) {
+	var_dump('ERROR 2', $e->getMessage());
+}
+
+echo "\n";
+
+$ref = new \ReflectionFunction(<<A2>> function () { });
+
+try {
+	$ref->getAttributes()[0]->getAsObject();
+} catch (\Error $e) {
+	var_dump('ERROR 3', $e->getMessage());
+}
+
+echo "\n";
+
+class A3
+{
+	private function __construct() { }
+}
+
+$ref = new \ReflectionFunction(<<A3>> function () { });
+
+try {
+	$ref->getAttributes()[0]->getAsObject();
+} catch (\Error $e) {
+	var_dump('ERROR 4', $e->getMessage());
+}
+
+echo "\n";
+
+class A4 { }
+
+$ref = new \ReflectionFunction(<<A4(1)>> function () { });
+
+try {
+	$ref->getAttributes()[0]->getAsObject();
+} catch (\Error $e) {
+	var_dump('ERROR 5', $e->getMessage());
+}
+
+?>
+--EXPECT--
+string(2) "A1"
+string(4) "test"
+int(50)
+
+string(7) "ERROR 1"
+string(81) "Too few arguments to function A1::__construct(), 0 passed and at least 1 expected"
+
+string(7) "ERROR 2"
+string(74) "A1::__construct(): Argument #1 ($name) must be of type string, array given"
+
+string(7) "ERROR 3"
+string(30) "Attribute class 'A2' not found"
+
+string(7) "ERROR 4"
+string(50) "Attribute constructor of class 'A3' must be public"
+
+string(7) "ERROR 5"
+string(71) "Attribute class 'A4' does not have a constructor, cannot pass arguments"

--- a/Zend/tests/attributes/006_filter.phpt
+++ b/Zend/tests/attributes/006_filter.phpt
@@ -1,0 +1,112 @@
+--TEST--
+Attributes can be filtered by name and base type.
+--FILE--
+<?php
+
+$ref = new \ReflectionFunction(<<A1>> <<A2>> function () { });
+$attr = $ref->getAttributes(A3::class);
+
+var_dump(count($attr));
+
+$ref = new \ReflectionFunction(<<A1>> <<A2>> function () { });
+$attr = $ref->getAttributes(A2::class);
+
+var_dump(count($attr), $attr[0]->getName());
+
+$ref = new \ReflectionFunction(<<A1>> <<A2>> <<A2>> function () { });
+$attr = $ref->getAttributes(A2::class);
+
+var_dump(count($attr), $attr[0]->getName(), $attr[1]->getName());
+
+echo "\n";
+
+interface Base { }
+class A1 implements Base { }
+class A2 implements Base { }
+class A3 extends A2 { }
+
+$ref = new \ReflectionFunction(<<A1>> <<A2>> <<A5>> function () { });
+$attr = $ref->getAttributes(\stdClass::class, \ReflectionAttribute::IS_INSTANCEOF);
+var_dump(count($attr));
+print_r(array_map(fn ($a) => $a->getName(), $attr));
+
+$ref = new \ReflectionFunction(<<A1>> <<A2>> function () { });
+$attr = $ref->getAttributes(A1::class, \ReflectionAttribute::IS_INSTANCEOF);
+var_dump(count($attr));
+print_r(array_map(fn ($a) => $a->getName(), $attr));
+
+$ref = new \ReflectionFunction(<<A1>> <<A2>> function () { });
+$attr = $ref->getAttributes(Base::class, \ReflectionAttribute::IS_INSTANCEOF);
+var_dump(count($attr));
+print_r(array_map(fn ($a) => $a->getName(), $attr));
+
+$ref = new \ReflectionFunction(<<A1>> <<A2>> <<A3>> function () { });
+$attr = $ref->getAttributes(A2::class, \ReflectionAttribute::IS_INSTANCEOF);
+var_dump(count($attr));
+print_r(array_map(fn ($a) => $a->getName(), $attr));
+
+$ref = new \ReflectionFunction(<<A1>> <<A2>> <<A3>> function () { });
+$attr = $ref->getAttributes(Base::class, \ReflectionAttribute::IS_INSTANCEOF);
+var_dump(count($attr));
+print_r(array_map(fn ($a) => $a->getName(), $attr));
+
+echo "\n";
+
+$ref = new \ReflectionFunction(function () { });
+
+try {
+	$ref->getAttributes(A1::class, 3);
+} catch (\Error $e) {
+	var_dump('ERROR 1', $e->getMessage());
+}
+
+$ref = new \ReflectionFunction(function () { });
+
+try {
+	$ref->getAttributes(SomeMissingClass::class, \ReflectionAttribute::IS_INSTANCEOF);
+} catch (\Error $e) {
+	var_dump('ERROR 2', $e->getMessage());
+}
+
+?>
+--EXPECT--
+int(0)
+int(1)
+string(2) "A2"
+int(2)
+string(2) "A2"
+string(2) "A2"
+
+int(0)
+Array
+(
+)
+int(1)
+Array
+(
+    [0] => A1
+)
+int(2)
+Array
+(
+    [0] => A1
+    [1] => A2
+)
+int(2)
+Array
+(
+    [0] => A2
+    [1] => A3
+)
+int(3)
+Array
+(
+    [0] => A1
+    [1] => A2
+    [2] => A3
+)
+
+string(7) "ERROR 1"
+string(39) "Invalid attribute filter flag specified"
+string(7) "ERROR 2"
+string(34) "Class 'SomeMissingClass' not found"

--- a/Zend/tests/attributes/007_wrong_compiler_attributes.phpt
+++ b/Zend/tests/attributes/007_wrong_compiler_attributes.phpt
@@ -9,6 +9,6 @@ class Foo
 }
 
 $ref = new ReflectionClass(Foo::class);
-var_dump($ref->getAttributes()[0]->getAsObject());
+var_dump($ref->getAttributes()[0]->newInstance());
 --EXPECTF--
 Fatal error: The PhpCompilerAttribute can only be used by internal classes, use PhpAttribute instead in %s

--- a/Zend/tests/attributes/007_wrong_compiler_attributes.phpt
+++ b/Zend/tests/attributes/007_wrong_compiler_attributes.phpt
@@ -1,0 +1,14 @@
+--TEST--
+attributes: Add PhpCompilerAttribute
+--FILE--
+<?php
+
+<<PhpCompilerAttribute>>
+class Foo
+{
+}
+
+$ref = new ReflectionClass(Foo::class);
+var_dump($ref->getAttributes()[0]->getAsObject());
+--EXPECTF--
+Fatal error: The PhpCompilerAttribute can only be used by internal classes, use PhpAttribute instead in %s

--- a/Zend/tests/attributes/008_wrong_attribution.phpt
+++ b/Zend/tests/attributes/008_wrong_attribution.phpt
@@ -1,0 +1,9 @@
+--TEST--
+Attributes: Prevent PhpAttribute on non classes
+--FILE--
+<?php
+
+<<PhpAttribute>>
+function foo() {}
+--EXPECTF--
+Fatal error: Only classes can be marked with <<PhpAttribute>> in %s

--- a/Zend/tests/attributes/009_doctrine_annotations_example.phpt
+++ b/Zend/tests/attributes/009_doctrine_annotations_example.phpt
@@ -2,57 +2,158 @@
 Doctrine-like attributes usage
 --FILE--
 <?php
-namespace Doctrine\ORM {
 
-	class Entity {
-		private $name;
-		public function __construct($name) {
-			$this->name = $name;
-		}
-	}
-
-	function GetClassAttributes($class_name) {
-		$reflClass = new \ReflectionClass($class_name);
-		$attrs = $reflClass->getAttributes();
-        $values = [];
-		foreach ($attrs as $attribute) {
-            $class = $attribute->getName();
-			$values[$attribute->getName()] = new $class(...$attribute->getArguments());
-		}
-		return $values;
-	}
+namespace Doctrine\ORM\Attributes {
+    class Annotation { public $values; public function construct() { $this->values = func_get_args(); } }
+    class Entity extends Annotation {}
+    class Id extends Annotation {}
+    class Column extends Annotation { const UNIQUE = 'unique'; const T_INTEGER = 'integer'; }
+    class GeneratedValue extends Annotation {}
+    class JoinTable extends Annotation {}
+    class ManyToMany extends Annotation {}
+    class JoinColumn extends Annotation { const UNIQUE = 'unique'; }
+    class InverseJoinColumn extends Annotation {}
 }
 
-namespace Doctrine\ORM\Mapping {
-    class Entity {
-        public $tableName;
-        public $repository;
-
-        public function __construct(array $values)
-        {
-            foreach ($values as $k => $v) {
-                $this->$k = $v;
-            }
-        }
-    }
+namespace Symfony\Component\Validator\Constraints {
+    class Annotation { public $values; public function construct() { $this->values = func_get_args(); } }
+    class Email extends Annotation {}
+    class Range extends Annotation {}
 }
 
 namespace {
-    use Doctrine\ORM\Mapping as ORM;
+use Doctrine\ORM\Attributes as ORM;
+use Symfony\Component\Validator\Constraints as Assert;
 
-	<<ORM\Entity(["tableName" => "user", "repository" => UserRepository::class])>>
-	class User {}
+<<ORM\Entity>>
+/** @ORM\Entity */
+class User
+{
+    /** @ORM\Id @ORM\Column(type="integer"*) @ORM\GeneratedValue */
+    <<ORM\Id>><<ORM\Column("integer")>><<ORM\GeneratedValue>>
+    private $id;
 
-	var_dump(Doctrine\ORM\GetClassAttributes("User"));
+    /**
+     * @ORM\Column(type="string", unique=true)
+     * @Assert\Email(message="The email '{{ value }}' is not a valid email.")
+     */
+    <<ORM\Column("string", ORM\Column::UNIQUE)>>
+    <<Assert\Email(array("message" => "The email '{{ value }}' is not a valid email."))>>
+    private $email;
+
+    /**
+     * @ORM\Column(type="integer")
+     * @Assert\Range(
+     *      min = 120,
+     *      max = 180,
+     *      minMessage = "You must be at least {{ limit }}cm tall to enter",
+     *      maxMessage = "You cannot be taller than {{ limit }}cm to enter"
+     * )
+     */
+    <<Assert\Range(["min" => 120, "max" => 180, "minMessage" => "You must be at least {{ limit }}cm tall to enter"])>>
+    <<ORM\Column(ORM\Column::T_INTEGER)>>
+    protected $height;
+
+    /**
+     * @ORM\ManyToMany(targetEntity="Phonenumber")
+     * @ORM\JoinTable(name="users_phonenumbers",
+     *      joinColumns={@ORM\JoinColumn(name="user_id", referencedColumnName="id")},
+     *      inverseJoinColumns={@ORM\JoinColumn(name="phonenumber_id", referencedColumnName="id", unique=true)}
+     *      )
+     */
+    <<ORM\ManyToMany(Phonenumber::class)>>
+    <<ORM\JoinTable("users_phonenumbers")>>
+    <<ORM\JoinColumn("user_id", "id")>>
+    <<ORM\InverseJoinColumn("phonenumber_id", "id", ORM\JoinColumn::UNIQUE)>>
+    private $phonenumbers;
+}
+
+$class = new ReflectionClass(User::class);
+$attributes = $class->getAttributes();
+
+foreach ($attributes as $attribute) {
+    var_dump($attribute->getName(), $attribute->getArguments());
+}
+
+foreach ($class->getProperties() as $property) {
+    $attributes = $property->getAttributes();
+
+    foreach ($attributes as $attribute) {
+        var_dump($attribute->getName(), $attribute->getArguments());
+    }
+}
 }
 ?>
 --EXPECT--
+string(30) "Doctrine\ORM\Attributes\Entity"
+array(0) {
+}
+string(26) "Doctrine\ORM\Attributes\Id"
+array(0) {
+}
+string(30) "Doctrine\ORM\Attributes\Column"
 array(1) {
-  ["Doctrine\ORM\Mapping\Entity"]=>
-  object(Doctrine\ORM\Mapping\Entity)#3 (2) {
-    ["tableName"]=>
-    string(4) "user"
-    ["repository"]=>
-    string(14) "UserRepository"
+  [0]=>
+  string(7) "integer"
+}
+string(38) "Doctrine\ORM\Attributes\GeneratedValue"
+array(0) {
+}
+string(30) "Doctrine\ORM\Attributes\Column"
+array(2) {
+  [0]=>
+  string(6) "string"
+  [1]=>
+  string(6) "unique"
+}
+string(45) "Symfony\Component\Validator\Constraints\Email"
+array(1) {
+  [0]=>
+  array(1) {
+    ["message"]=>
+    string(45) "The email '{{ value }}' is not a valid email."
   }
+}
+string(45) "Symfony\Component\Validator\Constraints\Range"
+array(1) {
+  [0]=>
+  array(3) {
+    ["min"]=>
+    int(120)
+    ["max"]=>
+    int(180)
+    ["minMessage"]=>
+    string(48) "You must be at least {{ limit }}cm tall to enter"
+  }
+}
+string(30) "Doctrine\ORM\Attributes\Column"
+array(1) {
+  [0]=>
+  string(7) "integer"
+}
+string(34) "Doctrine\ORM\Attributes\ManyToMany"
+array(1) {
+  [0]=>
+  string(11) "Phonenumber"
+}
+string(33) "Doctrine\ORM\Attributes\JoinTable"
+array(1) {
+  [0]=>
+  string(18) "users_phonenumbers"
+}
+string(34) "Doctrine\ORM\Attributes\JoinColumn"
+array(2) {
+  [0]=>
+  string(7) "user_id"
+  [1]=>
+  string(2) "id"
+}
+string(41) "Doctrine\ORM\Attributes\InverseJoinColumn"
+array(3) {
+  [0]=>
+  string(14) "phonenumber_id"
+  [1]=>
+  string(2) "id"
+  [2]=>
+  string(6) "unique"
 }

--- a/Zend/tests/attributes/009_doctrine_annotations_example.phpt
+++ b/Zend/tests/attributes/009_doctrine_annotations_example.phpt
@@ -1,0 +1,58 @@
+--TEST--
+Doctrine-like attributes usage
+--FILE--
+<?php
+namespace Doctrine\ORM {
+
+	class Entity {
+		private $name;
+		public function __construct($name) {
+			$this->name = $name;
+		}
+	}
+
+	function GetClassAttributes($class_name) {
+		$reflClass = new \ReflectionClass($class_name);
+		$attrs = $reflClass->getAttributes();
+        $values = [];
+		foreach ($attrs as $attribute) {
+            $class = $attribute->getName();
+			$values[$attribute->getName()] = new $class(...$attribute->getArguments());
+		}
+		return $values;
+	}
+}
+
+namespace Doctrine\ORM\Mapping {
+    class Entity {
+        public $tableName;
+        public $repository;
+
+        public function __construct(array $values)
+        {
+            foreach ($values as $k => $v) {
+                $this->$k = $v;
+            }
+        }
+    }
+}
+
+namespace {
+    use Doctrine\ORM\Mapping as ORM;
+
+	<<ORM\Entity(["tableName" => "user", "repository" => UserRepository::class])>>
+	class User {}
+
+	var_dump(Doctrine\ORM\GetClassAttributes("User"));
+}
+?>
+--EXPECT--
+array(1) {
+  ["Doctrine\ORM\Mapping\Entity"]=>
+  object(Doctrine\ORM\Mapping\Entity)#3 (2) {
+    ["tableName"]=>
+    string(4) "user"
+    ["repository"]=>
+    string(14) "UserRepository"
+  }
+}

--- a/Zend/tests/attributes/010_unsupported_const_expression.phpt
+++ b/Zend/tests/attributes/010_unsupported_const_expression.phpt
@@ -1,0 +1,11 @@
+--TEST--
+Attribute arguments support only const expressions.
+--FILE--
+<?php
+
+<<A1(foo())>>
+class C1 { }
+
+?>
+--EXPECTF--
+Fatal error: Constant expression contains invalid operations in %s

--- a/Zend/tests/attributes/011-inheritance.phpt
+++ b/Zend/tests/attributes/011-inheritance.phpt
@@ -1,0 +1,99 @@
+--TEST--
+Attributes comply with inheritance rules.
+--FILE--
+<?php
+
+<<A2>>
+class C1
+{
+	<<A1>>
+	public function foo() { }
+}
+
+class C2 extends C1
+{
+	public function foo() { }
+}
+
+class C3 extends C1
+{
+	<<A1>>
+	public function bar() { }
+}
+
+$ref = new \ReflectionClass(C1::class);
+print_r(array_map(fn ($a) => $a->getName(), $ref->getAttributes()));
+print_r(array_map(fn ($a) => $a->getName(), $ref->getMethod('foo')->getAttributes()));
+
+$ref = new \ReflectionClass(C2::class);
+print_r(array_map(fn ($a) => $a->getName(), $ref->getAttributes()));
+print_r(array_map(fn ($a) => $a->getName(), $ref->getMethod('foo')->getAttributes()));
+
+$ref = new \ReflectionClass(C3::class);
+print_r(array_map(fn ($a) => $a->getName(), $ref->getAttributes()));
+print_r(array_map(fn ($a) => $a->getName(), $ref->getMethod('foo')->getAttributes()));
+
+echo "\n";
+
+trait T1
+{
+	<<A2>>
+	public $a;
+}
+
+class C4
+{
+	use T1;
+}
+
+class C5
+{
+	use T1;
+	
+	public $a;
+}
+
+$ref = new \ReflectionClass(T1::class);
+print_r(array_map(fn ($a) => $a->getName(), $ref->getProperty('a')->getAttributes()));
+
+$ref = new \ReflectionClass(C4::class);
+print_r(array_map(fn ($a) => $a->getName(), $ref->getProperty('a')->getAttributes()));
+
+$ref = new \ReflectionClass(C5::class);
+print_r(array_map(fn ($a) => $a->getName(), $ref->getProperty('a')->getAttributes()));
+
+?>
+--EXPECT--
+Array
+(
+    [0] => A2
+)
+Array
+(
+    [0] => A1
+)
+Array
+(
+)
+Array
+(
+)
+Array
+(
+)
+Array
+(
+    [0] => A1
+)
+
+Array
+(
+    [0] => A2
+)
+Array
+(
+    [0] => A2
+)
+Array
+(
+)

--- a/Zend/tests/attributes/012-ast-export.phpt
+++ b/Zend/tests/attributes/012-ast-export.phpt
@@ -1,0 +1,54 @@
+--TEST--
+Attributes AST can be exported.
+--FILE--
+<?php
+
+assert(0 && ($a = <<A1>><<A2>> function ($a, <<A3(1)>> $b) { }));
+
+assert(0 && ($a = <<A1(1, 2, 1 + 2)>> fn () => 1));
+
+assert(0 && ($a = new <<A1>> class() {
+	<<A1>><<A2>> const FOO = 'foo';
+	<<A2>> public $x;
+	<<A3>> function a() { }
+}));
+
+assert(0 && ($a = function () {
+	<<A1>> class Test1 { }
+	<<A2>> interface Test2 { }
+	<<A3>> trait Test3 { }
+}));
+
+?>
+--EXPECTF--
+Warning: assert(): assert(0 && ($a = <<A1>> <<A2>> function ($a, <<A3(1)>> $b) {
+})) failed in %s on line %d
+
+Warning: assert(): assert(0 && ($a = <<A1(1, 2, 1 + 2)>> fn() => 1)) failed in %s on line %d
+
+Warning: assert(): assert(0 && ($a = new <<A1>> class {
+    <<A1>>
+    <<A2>>
+    const FOO = 'foo';
+    <<A2>>
+    public $x;
+    <<A3>>
+    public function a() {
+    }
+
+})) failed in %s on line %d
+
+Warning: assert(): assert(0 && ($a = function () {
+    <<A1>>
+    class Test1 {
+    }
+
+    <<A2>>
+    interface Test2 {
+    }
+
+    <<A3>>
+    trait Test3 {
+    }
+
+})) failed in %s on line %d

--- a/Zend/tests/varSyntax/globalNonSimpleVariableError.phpt
+++ b/Zend/tests/varSyntax/globalNonSimpleVariableError.phpt
@@ -7,4 +7,4 @@ global $$foo->bar;
 
 ?>
 --EXPECTF--
-Parse error: syntax error, unexpected '->' (T_OBJECT_OPERATOR), expecting ';' or ',' in %s on line %d
+Parse error: syntax error, unexpected '->' (T_OBJECT_OPERATOR), expecting ',' or ';' in %s on line %d

--- a/Zend/zend.h
+++ b/Zend/zend.h
@@ -177,6 +177,7 @@ struct _zend_class_entry {
 			uint32_t line_start;
 			uint32_t line_end;
 			zend_string *doc_comment;
+			HashTable *attributes;
 		} user;
 		struct {
 			const struct _zend_function_entry *builtin_functions;

--- a/Zend/zend_API.c
+++ b/Zend/zend_API.c
@@ -3513,7 +3513,7 @@ static zend_always_inline zend_bool is_persistent_class(zend_class_entry *ce) {
 		&& ce->info.internal.module->type == MODULE_PERSISTENT;
 }
 
-ZEND_API int zend_declare_typed_property(zend_class_entry *ce, zend_string *name, zval *property, int access_type, zend_string *doc_comment, zend_type type) /* {{{ */
+ZEND_API int zend_declare_typed_property(zend_class_entry *ce, zend_string *name, zval *property, int access_type, zend_string *doc_comment, HashTable *attributes, zend_type type) /* {{{ */
 {
 	zend_property_info *property_info, *property_info_ptr;
 
@@ -3612,6 +3612,7 @@ ZEND_API int zend_declare_typed_property(zend_class_entry *ce, zend_string *name
 	property_info->name = zend_new_interned_string(property_info->name);
 	property_info->flags = access_type;
 	property_info->doc_comment = doc_comment;
+	property_info->attributes = attributes;
 	property_info->ce = ce;
 	property_info->type = type;
 
@@ -3748,16 +3749,16 @@ ZEND_API int zend_try_assign_typed_ref_zval_ex(zend_reference *ref, zval *zv, ze
 }
 /* }}} */
 
-ZEND_API int zend_declare_property_ex(zend_class_entry *ce, zend_string *name, zval *property, int access_type, zend_string *doc_comment) /* {{{ */
+ZEND_API int zend_declare_property_ex(zend_class_entry *ce, zend_string *name, zval *property, int access_type, zend_string *doc_comment, HashTable *attributes) /* {{{ */
 {
-	return zend_declare_typed_property(ce, name, property, access_type, doc_comment, (zend_type) ZEND_TYPE_INIT_NONE(0));
+	return zend_declare_typed_property(ce, name, property, access_type, doc_comment, attributes, (zend_type) ZEND_TYPE_INIT_NONE(0));
 }
 /* }}} */
 
 ZEND_API int zend_declare_property(zend_class_entry *ce, const char *name, size_t name_length, zval *property, int access_type) /* {{{ */
 {
 	zend_string *key = zend_string_init(name, name_length, is_persistent_class(ce));
-	int ret = zend_declare_property_ex(ce, key, property, access_type, NULL);
+	int ret = zend_declare_property_ex(ce, key, property, access_type, NULL, NULL);
 	zend_string_release(key);
 	return ret;
 }
@@ -3817,7 +3818,7 @@ ZEND_API int zend_declare_property_stringl(zend_class_entry *ce, const char *nam
 }
 /* }}} */
 
-ZEND_API int zend_declare_class_constant_ex(zend_class_entry *ce, zend_string *name, zval *value, int access_type, zend_string *doc_comment) /* {{{ */
+ZEND_API int zend_declare_class_constant_ex(zend_class_entry *ce, zend_string *name, zval *value, int access_type, zend_string *doc_comment, HashTable *attributes) /* {{{ */
 {
 	zend_class_constant *c;
 
@@ -3844,6 +3845,7 @@ ZEND_API int zend_declare_class_constant_ex(zend_class_entry *ce, zend_string *n
 	ZVAL_COPY_VALUE(&c->value, value);
 	Z_ACCESS_FLAGS(c->value) = access_type;
 	c->doc_comment = doc_comment;
+	c->attributes = attributes;
 	c->ce = ce;
 	if (Z_TYPE_P(value) == IS_CONSTANT_AST) {
 		ce->ce_flags &= ~ZEND_ACC_CONSTANTS_UPDATED;
@@ -3869,7 +3871,7 @@ ZEND_API int zend_declare_class_constant(zend_class_entry *ce, const char *name,
 	} else {
 		key = zend_string_init(name, name_length, 0);
 	}
-	ret = zend_declare_class_constant_ex(ce, key, value, ZEND_ACC_PUBLIC, NULL);
+	ret = zend_declare_class_constant_ex(ce, key, value, ZEND_ACC_PUBLIC, NULL, NULL);
 	zend_string_release(key);
 	return ret;
 }

--- a/Zend/zend_API.h
+++ b/Zend/zend_API.h
@@ -350,9 +350,9 @@ ZEND_API zend_bool zend_make_callable(zval *callable, zend_string **callable_nam
 ZEND_API const char *zend_get_module_version(const char *module_name);
 ZEND_API int zend_get_module_started(const char *module_name);
 
-ZEND_API int zend_declare_typed_property(zend_class_entry *ce, zend_string *name, zval *property, int access_type, zend_string *doc_comment, zend_type type);
+ZEND_API int zend_declare_typed_property(zend_class_entry *ce, zend_string *name, zval *property, int access_type, zend_string *doc_comment, HashTable *attributes, zend_type type);
 
-ZEND_API int zend_declare_property_ex(zend_class_entry *ce, zend_string *name, zval *property, int access_type, zend_string *doc_comment);
+ZEND_API int zend_declare_property_ex(zend_class_entry *ce, zend_string *name, zval *property, int access_type, zend_string *doc_comment, HashTable *attributes);
 ZEND_API int zend_declare_property(zend_class_entry *ce, const char *name, size_t name_length, zval *property, int access_type);
 ZEND_API int zend_declare_property_null(zend_class_entry *ce, const char *name, size_t name_length, int access_type);
 ZEND_API int zend_declare_property_bool(zend_class_entry *ce, const char *name, size_t name_length, zend_long value, int access_type);
@@ -361,7 +361,7 @@ ZEND_API int zend_declare_property_double(zend_class_entry *ce, const char *name
 ZEND_API int zend_declare_property_string(zend_class_entry *ce, const char *name, size_t name_length, const char *value, int access_type);
 ZEND_API int zend_declare_property_stringl(zend_class_entry *ce, const char *name, size_t name_length, const char *value, size_t value_len, int access_type);
 
-ZEND_API int zend_declare_class_constant_ex(zend_class_entry *ce, zend_string *name, zval *value, int access_type, zend_string *doc_comment);
+ZEND_API int zend_declare_class_constant_ex(zend_class_entry *ce, zend_string *name, zval *value, int access_type, zend_string *doc_comment, HashTable *attributes);
 ZEND_API int zend_declare_class_constant(zend_class_entry *ce, const char *name, size_t name_length, zval *value);
 ZEND_API int zend_declare_class_constant_null(zend_class_entry *ce, const char *name, size_t name_length);
 ZEND_API int zend_declare_class_constant_long(zend_class_entry *ce, const char *name, size_t name_length, zend_long value);

--- a/Zend/zend_ast.c
+++ b/Zend/zend_ast.c
@@ -2141,8 +2141,7 @@ zend_ast * ZEND_FASTCALL zend_ast_with_attributes(zend_ast *ast, zend_ast *attr)
 		ast = zend_ast_create(ZEND_AST_CLASS_CONST_DECL_ATTRIBUTES, ast, attr);
 		ast->lineno = ast->child[0]->lineno;
 		break;
-	default:
-		zend_error_noreturn(E_COMPILE_ERROR, "Invalid use of attributes");
+	EMPTY_SWITCH_DEFAULT_CASE()
 	}
 
 	return ast;

--- a/Zend/zend_ast.h
+++ b/Zend/zend_ast.h
@@ -62,6 +62,7 @@ enum _zend_ast_kind {
 	ZEND_AST_TRAIT_ADAPTATIONS,
 	ZEND_AST_USE,
 	ZEND_AST_TYPE_UNION,
+	ZEND_AST_ATTRIBUTE_LIST,
 
 	/* 0 child nodes */
 	ZEND_AST_MAGIC_CONST = 0 << ZEND_AST_NUM_CHILDREN_SHIFT,
@@ -138,7 +139,8 @@ enum _zend_ast_kind {
 	ZEND_AST_USE_ELEM,
 	ZEND_AST_TRAIT_ALIAS,
 	ZEND_AST_GROUP_USE,
-	ZEND_AST_PROP_GROUP,
+	ZEND_AST_CLASS_CONST_DECL_ATTRIBUTES,
+	ZEND_AST_ATTRIBUTE,
 
 	/* 3 child nodes */
 	ZEND_AST_METHOD_CALL = 3 << ZEND_AST_NUM_CHILDREN_SHIFT,
@@ -147,13 +149,14 @@ enum _zend_ast_kind {
 
 	ZEND_AST_TRY,
 	ZEND_AST_CATCH,
-	ZEND_AST_PARAM,
+	ZEND_AST_PROP_GROUP,
 	ZEND_AST_PROP_ELEM,
 	ZEND_AST_CONST_ELEM,
 
 	/* 4 child nodes */
 	ZEND_AST_FOR = 4 << ZEND_AST_NUM_CHILDREN_SHIFT,
 	ZEND_AST_FOREACH,
+	ZEND_AST_PARAM,
 };
 
 typedef uint16_t zend_ast_kind;
@@ -191,6 +194,7 @@ typedef struct _zend_ast_decl {
 	uint32_t flags;
 	unsigned char *lex_pos;
 	zend_string *doc_comment;
+	zend_ast *attributes;
 	zend_string *name;
 	zend_ast *child[4];
 } zend_ast_decl;
@@ -311,6 +315,12 @@ static zend_always_inline zend_string *zend_ast_get_constant_name(zend_ast *ast)
 	return Z_STR(((zend_ast_zval *) ast)->val);
 }
 
+static zend_always_inline HashTable *zend_ast_get_hash(zend_ast *ast) {
+	zval *zv = zend_ast_get_zval(ast);
+	ZEND_ASSERT(Z_TYPE_P(zv) == IS_ARRAY);
+	return Z_ARR_P(zv);
+}
+
 static zend_always_inline uint32_t zend_ast_get_num_children(zend_ast *ast) {
 	ZEND_ASSERT(!zend_ast_is_list(ast));
 	return ast->kind >> ZEND_AST_NUM_CHILDREN_SHIFT;
@@ -322,6 +332,12 @@ static zend_always_inline uint32_t zend_ast_get_lineno(zend_ast *ast) {
 	} else {
 		return ast->lineno;
 	}
+}
+
+static zend_always_inline zend_ast *zend_ast_create_zval_from_hash(HashTable *hash) {
+	zval zv;
+	ZVAL_ARR(&zv, hash);
+	return zend_ast_create_zval(&zv);
 }
 
 static zend_always_inline zend_ast *zend_ast_create_binary_op(uint32_t opcode, zend_ast *op0, zend_ast *op1) {
@@ -340,4 +356,7 @@ static zend_always_inline zend_ast *zend_ast_list_rtrim(zend_ast *ast) {
 	}
 	return ast;
 }
+
+zend_ast * ZEND_FASTCALL zend_ast_with_attributes(zend_ast *ast, zend_ast *attr);
+
 #endif

--- a/Zend/zend_attributes.c
+++ b/Zend/zend_attributes.c
@@ -19,7 +19,20 @@ void zend_attribute_validate_phpcompilerattribute(zend_attribute *attr, int targ
 	zend_error(E_COMPILE_ERROR, "The PhpCompilerAttribute can only be used by internal classes, use PhpAttribute instead");
 }
 
-ZEND_API void zend_register_attribute_ce(void)
+ZEND_API zend_attributes_internal_validator zend_attribute_get_validator(zend_string *lcname)
+{
+	return zend_hash_find_ptr(&internal_validators, lcname);
+}
+
+ZEND_API void zend_compiler_attribute_register(zend_class_entry *ce, zend_attributes_internal_validator validator)
+{
+	zend_string *lcname = zend_string_tolower_ex(ce->name, 1);
+
+	zend_hash_update_ptr(&internal_validators, lcname, validator);
+	zend_string_release(lcname);
+}
+
+void zend_register_attribute_ce(void)
 {
 	zend_hash_init(&internal_validators, 8, NULL, NULL, 1);
 
@@ -36,17 +49,4 @@ ZEND_API void zend_register_attribute_ce(void)
 	zend_ce_php_compiler_attribute->ce_flags |= ZEND_ACC_FINAL;
 
 	zend_compiler_attribute_register(zend_ce_php_compiler_attribute, zend_attribute_validate_phpcompilerattribute);
-}
-
-ZEND_API zend_attributes_internal_validator zend_attribute_get_validator(zend_string *lcname)
-{
-	return zend_hash_find_ptr(&internal_validators, lcname);
-}
-
-ZEND_API void zend_compiler_attribute_register(zend_class_entry *ce, zend_attributes_internal_validator validator)
-{
-	zend_string *lcname = zend_string_tolower_ex(ce->name, 1);
-
-	zend_hash_update_ptr(&internal_validators, lcname, validator);
-	zend_string_release(lcname);
 }

--- a/Zend/zend_attributes.c
+++ b/Zend/zend_attributes.c
@@ -1,0 +1,43 @@
+#include "zend.h"
+#include "zend_API.h"
+#include "zend_attributes.h"
+
+void zend_attribute_validate_phpattribute(zval *attribute, int target)
+{
+	if (target != ZEND_ATTRIBUTE_TARGET_CLASS) {
+		zend_error(E_COMPILE_ERROR, "Only classes can be marked with <<PhpAttribute>>");
+	}
+}
+
+void zend_attribute_validate_phpcompilerattribute(zval *attribute, int target)
+{
+	zend_error(E_COMPILE_ERROR, "The PhpCompilerAttribute can only be used by internal classes, use PhpAttribute instead");
+}
+
+void zend_register_attribute_ce(void)
+{
+	zend_hash_init(&zend_attributes_internal_validators, 8, NULL, NULL, 1);
+
+	zend_class_entry ce;
+
+	INIT_CLASS_ENTRY(ce, "PhpAttribute", NULL);
+	zend_ce_php_attribute = zend_register_internal_class(&ce);
+	zend_ce_php_attribute->ce_flags |= ZEND_ACC_FINAL;
+
+	zend_compiler_attribute_register(zend_ce_php_attribute, zend_attribute_validate_phpattribute);
+
+	INIT_CLASS_ENTRY(ce, "PhpCompilerAttribute", NULL);
+	zend_ce_php_compiler_attribute = zend_register_internal_class(&ce);
+	zend_ce_php_compiler_attribute->ce_flags |= ZEND_ACC_FINAL;
+
+	zend_compiler_attribute_register(zend_ce_php_compiler_attribute, zend_attribute_validate_phpcompilerattribute);
+}
+
+void zend_compiler_attribute_register(zend_class_entry *ce, zend_attributes_internal_validator validator)
+{
+	zend_string *attribute_name = zend_string_tolower_ex(ce->name, 1);
+
+	zend_hash_update_ptr(&zend_attributes_internal_validators, attribute_name, validator);
+
+	zend_string_release(attribute_name);
+}

--- a/Zend/zend_attributes.c
+++ b/Zend/zend_attributes.c
@@ -2,14 +2,14 @@
 #include "zend_API.h"
 #include "zend_attributes.h"
 
-void zend_attribute_validate_phpattribute(zval *attribute, int target)
+void zend_attribute_validate_phpattribute(zend_attribute *attr, int target)
 {
 	if (target != ZEND_ATTRIBUTE_TARGET_CLASS) {
 		zend_error(E_COMPILE_ERROR, "Only classes can be marked with <<PhpAttribute>>");
 	}
 }
 
-void zend_attribute_validate_phpcompilerattribute(zval *attribute, int target)
+void zend_attribute_validate_phpcompilerattribute(zend_attribute *attr, int target)
 {
 	zend_error(E_COMPILE_ERROR, "The PhpCompilerAttribute can only be used by internal classes, use PhpAttribute instead");
 }

--- a/Zend/zend_attributes.h
+++ b/Zend/zend_attributes.h
@@ -12,7 +12,43 @@
 zend_class_entry *zend_ce_php_attribute;
 zend_class_entry *zend_ce_php_compiler_attribute;
 
-typedef void (*zend_attributes_internal_validator)(zval *attribute, int target);
+typedef struct _zend_attribute {
+	zend_string *name;
+	zend_string *lcname;
+	uint32_t offset;
+	uint32_t argc;
+	zval argv[1];
+} zend_attribute;
+
+static zend_always_inline zend_bool zend_has_attribute(HashTable *attributes, zend_string *name, uint32_t offset)
+{
+	if (attributes) {
+		zend_attribute *attr;
+
+		ZEND_HASH_FOREACH_PTR(attributes, attr) {
+			if (attr->offset == offset && zend_string_equals(attr->lcname, name)) {
+				return 1;
+			}
+		} ZEND_HASH_FOREACH_END();
+	}
+
+	return 0;
+}
+
+static zend_always_inline zend_bool zend_has_attribute_str(HashTable *attributes, const char *str, size_t len, uint32_t offset)
+{
+	zend_bool result = 0;
+
+	if (attributes) {
+		zend_string *name = zend_string_init(str, len, 0);
+		result = zend_has_attribute(attributes, name, offset);
+		zend_string_release(name);
+	}
+
+	return result;
+}
+
+typedef void (*zend_attributes_internal_validator)(zend_attribute *attr, int target);
 HashTable zend_attributes_internal_validators;
 
 void zend_compiler_attribute_register(zend_class_entry *ce, zend_attributes_internal_validator validator);

--- a/Zend/zend_attributes.h
+++ b/Zend/zend_attributes.h
@@ -12,6 +12,8 @@
 zend_class_entry *zend_ce_php_attribute;
 zend_class_entry *zend_ce_php_compiler_attribute;
 
+#define ZEND_ATTRIBUTE_SIZE(argc) (sizeof(zend_attribute) + sizeof(zval) * (argc) - sizeof(zval))
+
 typedef struct _zend_attribute {
 	zend_string *name;
 	zend_string *lcname;
@@ -19,6 +21,20 @@ typedef struct _zend_attribute {
 	uint32_t argc;
 	zval argv[1];
 } zend_attribute;
+
+static zend_always_inline void zend_attribute_release(zend_attribute *attr)
+{
+	uint32_t i;
+
+	zend_string_release(attr->name);
+	zend_string_release(attr->lcname);
+
+	for (i = 0; i < attr->argc; i++) {
+		zval_ptr_dtor(&attr->argv[i]);
+	}
+
+	efree(attr);
+}
 
 static zend_always_inline zend_bool zend_has_attribute(HashTable *attributes, zend_string *name, uint32_t offset)
 {

--- a/Zend/zend_attributes.h
+++ b/Zend/zend_attributes.h
@@ -1,0 +1,20 @@
+#ifndef ZEND_ATTRIBUTES_H
+#define ZEND_ATTRIBUTES_H
+
+#define ZEND_ATTRIBUTE_TARGET_CLASS			1
+#define ZEND_ATTRIBUTE_TARGET_FUNCTION		2
+#define ZEND_ATTRIBUTE_TARGET_METHOD		4
+#define ZEND_ATTRIBUTE_TARGET_PROPERTY		8
+#define ZEND_ATTRIBUTE_TARGET_CLASS_CONST	16
+#define ZEND_ATTRIBUTE_TARGET_PARAMETER		32
+#define ZEND_ATTRIBUTE_TARGET_ALL			63
+
+zend_class_entry *zend_ce_php_attribute;
+zend_class_entry *zend_ce_php_compiler_attribute;
+
+typedef void (*zend_attributes_internal_validator)(zval *attribute, int target);
+HashTable zend_attributes_internal_validators;
+
+void zend_compiler_attribute_register(zend_class_entry *ce, zend_attributes_internal_validator validator);
+void zend_register_attribute_ce(void);
+#endif

--- a/Zend/zend_attributes.h
+++ b/Zend/zend_attributes.h
@@ -74,7 +74,8 @@ static zend_always_inline zend_attribute *zend_get_attribute_str(HashTable *attr
 
 ZEND_API void zend_compiler_attribute_register(zend_class_entry *ce, zend_attributes_internal_validator validator);
 ZEND_API zend_attributes_internal_validator zend_attribute_get_validator(zend_string *lcname);
-ZEND_API void zend_register_attribute_ce(void);
+
+void zend_register_attribute_ce(void);
 
 END_EXTERN_C()
 

--- a/Zend/zend_attributes.h
+++ b/Zend/zend_attributes.h
@@ -9,10 +9,12 @@
 #define ZEND_ATTRIBUTE_TARGET_PARAMETER		32
 #define ZEND_ATTRIBUTE_TARGET_ALL			63
 
-zend_class_entry *zend_ce_php_attribute;
-zend_class_entry *zend_ce_php_compiler_attribute;
-
 #define ZEND_ATTRIBUTE_SIZE(argc) (sizeof(zend_attribute) + sizeof(zval) * (argc) - sizeof(zval))
+
+BEGIN_EXTERN_C()
+
+extern ZEND_API zend_class_entry *zend_ce_php_attribute;
+extern ZEND_API zend_class_entry *zend_ce_php_compiler_attribute;
 
 typedef struct _zend_attribute {
 	zend_string *name;
@@ -22,7 +24,9 @@ typedef struct _zend_attribute {
 	zval argv[1];
 } zend_attribute;
 
-static zend_always_inline void zend_attribute_release(zend_attribute *attr)
+typedef void (*zend_attributes_internal_validator)(zend_attribute *attr, int target);
+
+static zend_always_inline void zend_attribute_free(zend_attribute *attr)
 {
 	uint32_t i;
 
@@ -36,37 +40,42 @@ static zend_always_inline void zend_attribute_release(zend_attribute *attr)
 	efree(attr);
 }
 
-static zend_always_inline zend_bool zend_has_attribute(HashTable *attributes, zend_string *name, uint32_t offset)
+static zend_always_inline zend_attribute *zend_get_attribute(HashTable *attributes, zend_string *name, uint32_t offset)
 {
 	if (attributes) {
 		zend_attribute *attr;
 
 		ZEND_HASH_FOREACH_PTR(attributes, attr) {
 			if (attr->offset == offset && zend_string_equals(attr->lcname, name)) {
-				return 1;
+				return attr;
 			}
 		} ZEND_HASH_FOREACH_END();
 	}
 
-	return 0;
+	return NULL;
 }
 
-static zend_always_inline zend_bool zend_has_attribute_str(HashTable *attributes, const char *str, size_t len, uint32_t offset)
+static zend_always_inline zend_attribute *zend_get_attribute_str(HashTable *attributes, const char *str, size_t len, uint32_t offset)
 {
-	zend_bool result = 0;
-
 	if (attributes) {
-		zend_string *name = zend_string_init(str, len, 0);
-		result = zend_has_attribute(attributes, name, offset);
-		zend_string_release(name);
+		zend_attribute *attr;
+
+		ZEND_HASH_FOREACH_PTR(attributes, attr) {
+			if (attr->offset == offset && ZSTR_LEN(attr->lcname) == len) {
+				if (0 == memcmp(ZSTR_VAL(attr->lcname), str, len)) {
+					return attr;
+				}
+			}
+		} ZEND_HASH_FOREACH_END();
 	}
 
-	return result;
+	return NULL;
 }
 
-typedef void (*zend_attributes_internal_validator)(zend_attribute *attr, int target);
-HashTable zend_attributes_internal_validators;
+ZEND_API void zend_compiler_attribute_register(zend_class_entry *ce, zend_attributes_internal_validator validator);
+ZEND_API zend_attributes_internal_validator zend_attribute_get_validator(zend_string *lcname);
+ZEND_API void zend_register_attribute_ce(void);
 
-void zend_compiler_attribute_register(zend_class_entry *ce, zend_attributes_internal_validator validator);
-void zend_register_attribute_ce(void);
+END_EXTERN_C()
+
 #endif

--- a/Zend/zend_compile.c
+++ b/Zend/zend_compile.c
@@ -5722,7 +5722,7 @@ static zend_attribute *zend_compile_attribute(zend_ast *ast, uint32_t offset) /*
 	ZEND_ASSERT(ast->kind == ZEND_AST_ATTRIBUTE);
 
 	zend_ast_list *list = ast->child[1] ? zend_ast_get_list(ast->child[1]) : NULL;
-	zend_attribute *attr = emalloc(sizeof(zend_attribute) + sizeof(zval) * (list ? list->children : 0));
+	zend_attribute *attr = emalloc(ZEND_ATTRIBUTE_SIZE(list ? list->children : 0));
 
 	attr->name = zend_resolve_class_name_ast(ast->child[0]);
 	attr->lcname = zend_string_tolower(attr->name);
@@ -5743,21 +5743,10 @@ static zend_attribute *zend_compile_attribute(zend_ast *ast, uint32_t offset) /*
 }
 /* }}} */
 
-static void attribute_ptr_dtor(zval *v) /* {{{ */
+static void attribute_ptr_dtor(zval *v)
 {
-	zend_attribute *attr = Z_PTR_P(v);
-	uint32_t i;
-
-	zend_string_release(attr->name);
-	zend_string_release(attr->lcname);
-
-	for (i = 0; i < attr->argc; i++) {
-		zval_ptr_dtor(&attr->argv[i]);
-	}
-
-	efree(attr);
+	zend_attribute_release((zend_attribute *) Z_PTR_P(v));
 }
-/* }}} */
 
 static zend_always_inline HashTable *create_attribute_array(uint32_t size) /* {{{ */
 {

--- a/Zend/zend_compile.c
+++ b/Zend/zend_compile.c
@@ -5769,7 +5769,7 @@ static void zend_compile_attributes(HashTable *attributes, zend_ast *ast, uint32
 	ZEND_ASSERT(ast->kind == ZEND_AST_ATTRIBUTE_LIST);
 
 	for (i = 0; i < list->children; i++) {
-		zend_attribute *attr = zend_compile_attribute(list->child[i], 0);
+		zend_attribute *attr = zend_compile_attribute(list->child[i], offset);
 
 		// Validate internal attribute
 		zend_attributes_internal_validator validator = zend_hash_find_ptr(&zend_attributes_internal_validators, attr->lcname);

--- a/Zend/zend_compile.c
+++ b/Zend/zend_compile.c
@@ -5743,10 +5743,11 @@ static zend_attribute *zend_compile_attribute(zend_ast *ast, uint32_t offset) /*
 }
 /* }}} */
 
-static void attribute_ptr_dtor(zval *v)
+static void attribute_ptr_dtor(zval *v) /* {{{ */
 {
-	zend_attribute_release((zend_attribute *) Z_PTR_P(v));
+	zend_attribute_free((zend_attribute *) Z_PTR_P(v));
 }
+/* }}} */
 
 static zend_always_inline HashTable *create_attribute_array(uint32_t size) /* {{{ */
 {
@@ -5772,7 +5773,7 @@ static void zend_compile_attributes(HashTable *attributes, zend_ast *ast, uint32
 		zend_attribute *attr = zend_compile_attribute(list->child[i], offset);
 
 		// Validate internal attribute
-		zend_attributes_internal_validator validator = zend_hash_find_ptr(&zend_attributes_internal_validators, attr->lcname);
+		zend_attributes_internal_validator validator = zend_attribute_get_validator(attr->lcname);
 
 		if (validator != NULL) {
 			validator(attr, target);

--- a/Zend/zend_compile.h
+++ b/Zend/zend_compile.h
@@ -120,6 +120,7 @@ typedef struct _zend_file_context {
 typedef union _zend_parser_stack_elem {
 	zend_ast *ast;
 	zend_string *str;
+	HashTable *hash;
 	zend_ulong num;
 	unsigned char *ptr;
 } zend_parser_stack_elem;
@@ -351,6 +352,7 @@ typedef struct _zend_property_info {
 	uint32_t flags;
 	zend_string *name;
 	zend_string *doc_comment;
+	HashTable *attributes;
 	zend_class_entry *ce;
 	zend_type type;
 } zend_property_info;
@@ -367,6 +369,7 @@ typedef struct _zend_property_info {
 typedef struct _zend_class_constant {
 	zval value; /* access flags are stored in reserved: zval.u2.access_flags */
 	zend_string *doc_comment;
+	HashTable *attributes;
 	zend_class_entry *ce;
 } zend_class_constant;
 
@@ -430,6 +433,7 @@ struct _zend_op_array {
 	uint32_t line_start;
 	uint32_t line_end;
 	zend_string *doc_comment;
+	HashTable   *attributes;
 
 	int last_literal;
 	zval *literals;

--- a/Zend/zend_default_classes.c
+++ b/Zend/zend_default_classes.c
@@ -19,6 +19,7 @@
 
 #include "zend.h"
 #include "zend_API.h"
+#include "zend_attributes.h"
 #include "zend_builtin_functions.h"
 #include "zend_interfaces.h"
 #include "zend_exceptions.h"
@@ -34,4 +35,5 @@ ZEND_API void zend_register_default_classes(void)
 	zend_register_closure_ce();
 	zend_register_generator_ce();
 	zend_register_weakref_ce();
+	zend_register_attribute_ce();
 }

--- a/Zend/zend_inheritance.c
+++ b/Zend/zend_inheritance.c
@@ -2046,7 +2046,10 @@ static void zend_do_traits_property_binding(zend_class_entry *ce, zend_class_ent
 			doc_comment = property_info->doc_comment ? zend_string_copy(property_info->doc_comment) : NULL;
 			if (property_info->attributes) {
 				attributes = property_info->attributes;
-				GC_ADDREF(attributes);
+
+				if (!(GC_FLAGS(attributes) & IS_ARRAY_IMMUTABLE)) {
+					GC_ADDREF(attributes);
+				}
 			}
 			zend_type_copy_ctor(&property_info->type, /* persistent */ 0);
 			zend_declare_typed_property(ce, prop_name, prop_value, flags, doc_comment, attributes, property_info->type);

--- a/Zend/zend_inheritance.c
+++ b/Zend/zend_inheritance.c
@@ -1944,6 +1944,7 @@ static void zend_do_traits_property_binding(zend_class_entry *ce, zend_class_ent
 	zval* prop_value;
 	uint32_t flags;
 	zend_string *doc_comment;
+	HashTable *attributes = NULL;
 
 	/* In the following steps the properties are inserted into the property table
 	 * for that, a very strict approach is applied:
@@ -2043,8 +2044,12 @@ static void zend_do_traits_property_binding(zend_class_entry *ce, zend_class_ent
 
 			Z_TRY_ADDREF_P(prop_value);
 			doc_comment = property_info->doc_comment ? zend_string_copy(property_info->doc_comment) : NULL;
+			if (property_info->attributes) {
+				attributes = property_info->attributes;
+				GC_ADDREF(attributes);
+			}
 			zend_type_copy_ctor(&property_info->type, /* persistent */ 0);
-			zend_declare_typed_property(ce, prop_name, prop_value, flags, doc_comment, property_info->type);
+			zend_declare_typed_property(ce, prop_name, prop_value, flags, doc_comment, attributes, property_info->type);
 			zend_string_release_ex(prop_name, 0);
 		} ZEND_HASH_FOREACH_END();
 	}

--- a/Zend/zend_language_parser.y
+++ b/Zend/zend_language_parser.y
@@ -227,7 +227,7 @@ static YYSIZE_T zend_yytnamerr(char*, const char*);
 /* Token used to force a parse error from the lexer */
 %token T_ERROR
 
-%type <ast> top_statement namespace_name name statement annotated_statement function_declaration_statement
+%type <ast> top_statement namespace_name name statement function_declaration_statement
 %type <ast> class_declaration_statement trait_declaration_statement
 %type <ast> interface_declaration_statement interface_extends_list
 %type <ast> group_use_declaration inline_use_declarations inline_use_declaration
@@ -235,8 +235,8 @@ static YYSIZE_T zend_yytnamerr(char*, const char*);
 %type <ast> unprefixed_use_declarations const_decl inner_statement
 %type <ast> expr optional_expr while_statement for_statement foreach_variable
 %type <ast> foreach_statement declare_statement finally_statement unset_variable variable
-%type <ast> extends_from annotated_parameter parameter optional_type_without_static argument global_var
-%type <ast> static_var class_statement annotated_class_statement trait_adaptation trait_precedence trait_alias
+%type <ast> extends_from parameter optional_type_without_static argument global_var
+%type <ast> static_var class_statement trait_adaptation trait_precedence trait_alias
 %type <ast> absolute_trait_method_reference trait_method_reference property echo_expr
 %type <ast> new_expr anonymous_class class_name class_name_reference simple_variable
 %type <ast> internal_functions_in_yacc
@@ -257,6 +257,7 @@ static YYSIZE_T zend_yytnamerr(char*, const char*);
 %type <ast> isset_variable type return_type type_expr type_without_static
 %type <ast> identifier type_expr_without_static union_type_without_static
 %type <ast> inline_function union_type
+%type <ast> annotated_statement annotated_class_statement annotated_parameter
 %type <ast> attribute_arguments attribute_decl attribute attributes
 
 %type <num> returns_ref function fn is_reference is_variadic variable_modifiers

--- a/Zend/zend_opcode.c
+++ b/Zend/zend_opcode.c
@@ -319,7 +319,7 @@ ZEND_API void destroy_zend_class(zval *zv)
 						zend_string_release_ex(prop_info->doc_comment, 0);
 					}
 					if (prop_info->attributes) {
-						zend_array_ptr_dtor(prop_info->attributes);
+						zend_array_release(prop_info->attributes);
 					}
 					zend_type_release(prop_info->type, /* persistent */ 0);
 				}
@@ -337,7 +337,7 @@ ZEND_API void destroy_zend_class(zval *zv)
 							zend_string_release_ex(c->doc_comment, 0);
 						}
 						if (c->attributes) {
-							zend_array_ptr_dtor(c->attributes);
+							zend_array_release(c->attributes);
 						}
 					}
 				} ZEND_HASH_FOREACH_END();
@@ -358,7 +358,7 @@ ZEND_API void destroy_zend_class(zval *zv)
 				zend_string_release_ex(ce->info.user.doc_comment, 0);
 			}
 			if (ce->info.user.attributes) {
-				zend_array_ptr_dtor(ce->info.user.attributes);
+				zend_array_release(ce->info.user.attributes);
 			}
 
 			if (ce->num_traits > 0) {
@@ -412,7 +412,7 @@ ZEND_API void destroy_zend_class(zval *zv)
 							zend_string_release_ex(c->doc_comment, 1);
 						}
 						if (c->attributes) {
-							zend_array_ptr_dtor(c->attributes);
+							zend_array_release(c->attributes);
 						}
 					}
 					free(c);
@@ -497,7 +497,7 @@ ZEND_API void destroy_op_array(zend_op_array *op_array)
 		zend_string_release_ex(op_array->doc_comment, 0);
 	}
 	if (op_array->attributes) {
-		zend_array_ptr_dtor(op_array->attributes);
+		zend_array_release(op_array->attributes);
 	}
 	if (op_array->live_range) {
 		efree(op_array->live_range);

--- a/Zend/zend_opcode.c
+++ b/Zend/zend_opcode.c
@@ -63,6 +63,7 @@ void init_op_array(zend_op_array *op_array, zend_uchar type, int initial_ops_siz
 	op_array->function_name = NULL;
 	op_array->filename = zend_get_compiled_filename();
 	op_array->doc_comment = NULL;
+	op_array->attributes = NULL;
 
 	op_array->arg_info = NULL;
 	op_array->num_args = 0;
@@ -317,6 +318,9 @@ ZEND_API void destroy_zend_class(zval *zv)
 					if (prop_info->doc_comment) {
 						zend_string_release_ex(prop_info->doc_comment, 0);
 					}
+					if (prop_info->attributes) {
+						zend_array_ptr_dtor(prop_info->attributes);
+					}
 					zend_type_release(prop_info->type, /* persistent */ 0);
 				}
 			} ZEND_HASH_FOREACH_END();
@@ -331,6 +335,9 @@ ZEND_API void destroy_zend_class(zval *zv)
 						zval_ptr_dtor_nogc(&c->value);
 						if (c->doc_comment) {
 							zend_string_release_ex(c->doc_comment, 0);
+						}
+						if (c->attributes) {
+							zend_array_ptr_dtor(c->attributes);
 						}
 					}
 				} ZEND_HASH_FOREACH_END();
@@ -349,6 +356,9 @@ ZEND_API void destroy_zend_class(zval *zv)
 			}
 			if (ce->info.user.doc_comment) {
 				zend_string_release_ex(ce->info.user.doc_comment, 0);
+			}
+			if (ce->info.user.attributes) {
+				zend_array_ptr_dtor(ce->info.user.attributes);
 			}
 
 			if (ce->num_traits > 0) {
@@ -400,6 +410,9 @@ ZEND_API void destroy_zend_class(zval *zv)
 						zval_internal_ptr_dtor(&c->value);
 						if (c->doc_comment) {
 							zend_string_release_ex(c->doc_comment, 1);
+						}
+						if (c->attributes) {
+							zend_array_ptr_dtor(c->attributes);
 						}
 					}
 					free(c);
@@ -482,6 +495,9 @@ ZEND_API void destroy_op_array(zend_op_array *op_array)
 
 	if (op_array->doc_comment) {
 		zend_string_release_ex(op_array->doc_comment, 0);
+	}
+	if (op_array->attributes) {
+		zend_array_ptr_dtor(op_array->attributes);
 	}
 	if (op_array->live_range) {
 		efree(op_array->live_range);

--- a/Zend/zend_variables.h
+++ b/Zend/zend_variables.h
@@ -48,7 +48,7 @@ static zend_always_inline void i_zval_ptr_dtor(zval *zval_ptr)
 	}
 }
 
-static zend_always_inline void zend_array_ptr_dtor(zend_array *array)
+static zend_always_inline void zend_array_release(zend_array *array)
 {
 	if (!(GC_FLAGS(array) & IS_ARRAY_IMMUTABLE)) {
 		if (GC_DELREF(array) == 0) {

--- a/Zend/zend_variables.h
+++ b/Zend/zend_variables.h
@@ -48,6 +48,15 @@ static zend_always_inline void i_zval_ptr_dtor(zval *zval_ptr)
 	}
 }
 
+static zend_always_inline void zend_array_ptr_dtor(zend_array *array)
+{
+	if (!(GC_FLAGS(array) & IS_ARRAY_IMMUTABLE)) {
+		if (GC_DELREF(array) == 0) {
+			zend_array_destroy(array);
+		}
+	}
+}
+
 static zend_always_inline void zval_copy_ctor(zval *zvalue)
 {
 	if (Z_TYPE_P(zvalue) == IS_ARRAY) {

--- a/configure.ac
+++ b/configure.ac
@@ -1457,7 +1457,7 @@ PHP_ADD_SOURCES(Zend, \
     zend_execute_API.c zend_highlight.c zend_llist.c \
     zend_vm_opcodes.c zend_opcode.c zend_operators.c zend_ptr_stack.c zend_stack.c \
     zend_variables.c zend.c zend_API.c zend_extensions.c zend_hash.c \
-    zend_list.c zend_builtin_functions.c \
+    zend_list.c zend_builtin_functions.c zend_attributes.c \
     zend_ini.c zend_sort.c zend_multibyte.c zend_ts_hash.c zend_stream.c \
     zend_iterators.c zend_interfaces.c zend_exceptions.c zend_strtod.c zend_gc.c \
     zend_closures.c zend_weakrefs.c zend_float.c zend_string.c zend_signal.c zend_generators.c \

--- a/ext/opcache/jit/zend_jit.h
+++ b/ext/opcache/jit/zend_jit.h
@@ -32,7 +32,7 @@
 #define ZEND_JIT_ON_FIRST_EXEC     1
 #define ZEND_JIT_ON_PROF_REQUEST   2     /* compile the most frequently caled on first request functions */
 #define ZEND_JIT_ON_HOT_COUNTERS   3     /* compile functions after N calls or loop iterations */
-#define ZEND_JIT_ON_DOC_COMMENT    4     /* compile functions with "@jit" tag in doc-comments */
+#define ZEND_JIT_ON_ATTRIBUTE      4     /* compile functions with "Opcache\Jit" attribute */
 #define ZEND_JIT_ON_HOT_TRACE      5     /* trace functions after N calls or loop iterations */
 
 #define ZEND_JIT_TRIGGER(n)        (((n) / 10) % 10)
@@ -128,5 +128,7 @@ struct _zend_lifetime_interval {
 	zend_lifetime_interval *used_as_hint;
 	zend_lifetime_interval *list_next;
 };
+
+zend_class_entry *zend_ce_opcache_jit_attribute;
 
 #endif /* HAVE_JIT_H */

--- a/ext/opcache/tests/jit/attribute_001.phpt
+++ b/ext/opcache/tests/jit/attribute_001.phpt
@@ -1,0 +1,26 @@
+--TEST--
+Opcache\Jit Attribute
+--INI--
+opcache.enable=1
+opcache.enable_cli=1
+opcache.file_update_protection=0
+opcache.jit_buffer_size=64
+opcache.jit=1245
+opcache.jit_debug=257
+--SKIPIF--
+<?php require_once('skipif.inc'); ?>
+--FILE--
+<?php
+
+<<Opcache\Jit(true)>>
+function test() {
+    return 1234;
+}
+function test2() {
+}
+
+test2();
+test();
+?>
+--EXPECTF--
+JIT$test: ; (%s)%A

--- a/ext/opcache/tests/jit/attribute_002.phpt
+++ b/ext/opcache/tests/jit/attribute_002.phpt
@@ -1,0 +1,32 @@
+--TEST--
+Opcache\Jit Attribute disables function
+--INI--
+opcache.enable=1
+opcache.enable_cli=1
+opcache.file_update_protection=0
+opcache.jit_buffer_size=64
+opcache.jit=1205
+opcache.jit_debug=257
+--SKIPIF--
+<?php require_once('skipif.inc'); ?>
+--FILE--
+<?php
+
+<<Opcache\Jit(false)>>
+function test() {
+    return 1234;
+}
+function test2() {
+}
+
+test();
+test2();
+?>
+--EXPECTF--
+JIT$%s: ; (%s)
+	sub $0x10, %s
+	add $0x10, %s
+	mov $ZEND_RETURN_SPEC_CONST_LABEL, %s
+	jmp *%s
+
+JIT$test2: ; (%s)%A

--- a/ext/opcache/tests/jit/attribute_003.phpt
+++ b/ext/opcache/tests/jit/attribute_003.phpt
@@ -1,0 +1,13 @@
+--TEST--
+Opcache\Jit on wrong declaration
+--SKIPIF--
+<?php require_once('skipif.inc'); ?>
+--FILE--
+<?php
+
+class Foo {
+    <<\Opcache\Jit>>
+    public $foo;
+}
+--EXPECTF--
+Fatal error: <<Opcache\Jit>> attribute can only be declared on methods or functions in %s

--- a/ext/opcache/tests/jit/attribute_004.phpt
+++ b/ext/opcache/tests/jit/attribute_004.phpt
@@ -1,0 +1,12 @@
+--TEST--
+Opcache\Jit too many arguments
+--SKIPIF--
+<?php require_once('skipif.inc'); ?>
+--FILE--
+<?php
+
+<<\Opcache\Jit(false, true)>>
+function test() {
+}
+--EXPECTF--
+Fatal error: <<Opcache\Jit>> requires zero or one argument, 2 arguments given in %s

--- a/ext/opcache/tests/jit/attribute_005.phpt
+++ b/ext/opcache/tests/jit/attribute_005.phpt
@@ -1,0 +1,12 @@
+--TEST--
+Opcache\Jit not boolean
+--SKIPIF--
+<?php require_once('skipif.inc'); ?>
+--FILE--
+<?php
+
+<<\Opcache\Jit("true")>>
+function test() {
+}
+--EXPECTF--
+Fatal error: <<Opcache\Jit>> first argument $enabled must be a boolean in %s

--- a/ext/opcache/zend_file_cache.c
+++ b/ext/opcache/zend_file_cache.c
@@ -158,6 +158,25 @@ static int zend_file_cache_flock(int fd, int type)
 		} \
 	} while (0)
 
+#define SERIALIZE_ATTRIBUTES(attr) do { \
+	if ((attr) && !IS_SERIALIZED(attr)) { \
+		HashTable *ht; \
+		SERIALIZE_PTR(attr); \
+		ht = (attr); \
+		UNSERIALIZE_PTR(ht); \
+		zend_file_cache_serialize_hash(ht, script, info, buf, zend_file_cache_serialize_zval); \
+	} \
+} while (0)
+
+#define UNSERIALIZE_ATTRIBUTES(attr) do { \
+	if ((attr) && !IS_UNSERIALIZED(attr)) { \
+		HashTable *ht; \
+		UNSERIALIZE_PTR(attr); \
+		ht = (attr); \
+		zend_file_cache_unserialize_hash(ht, script, buf, zend_file_cache_unserialize_zval, ZVAL_PTR_DTOR); \
+	} \
+} while (0)
+
 static const uint32_t uninitialized_bucket[-HT_MIN_MASK] =
 	{HT_INVALID_IDX, HT_INVALID_IDX};
 
@@ -421,6 +440,7 @@ static void zend_file_cache_serialize_op_array(zend_op_array            *op_arra
 			SERIALIZE_PTR(op_array->live_range);
 			SERIALIZE_PTR(op_array->scope);
 			SERIALIZE_STR(op_array->doc_comment);
+			SERIALIZE_ATTRIBUTES(op_array->attributes);
 			SERIALIZE_PTR(op_array->try_catch_array);
 			SERIALIZE_PTR(op_array->prototype);
 			return;
@@ -547,6 +567,7 @@ static void zend_file_cache_serialize_op_array(zend_op_array            *op_arra
 		SERIALIZE_PTR(op_array->live_range);
 		SERIALIZE_PTR(op_array->scope);
 		SERIALIZE_STR(op_array->doc_comment);
+		SERIALIZE_ATTRIBUTES(op_array->attributes);
 		SERIALIZE_PTR(op_array->try_catch_array);
 		SERIALIZE_PTR(op_array->prototype);
 
@@ -591,6 +612,8 @@ static void zend_file_cache_serialize_prop_info(zval                     *zv,
 			if (prop->doc_comment) {
 				SERIALIZE_STR(prop->doc_comment);
 			}
+			SERIALIZE_ATTRIBUTES(prop->attributes);
+
 			zend_file_cache_serialize_type(&prop->type, script, info, buf);
 		}
 	}
@@ -617,6 +640,8 @@ static void zend_file_cache_serialize_class_constant(zval                     *z
 			if (c->doc_comment) {
 				SERIALIZE_STR(c->doc_comment);
 			}
+
+			SERIALIZE_ATTRIBUTES(c->attributes);
 		}
 	}
 }
@@ -674,6 +699,7 @@ static void zend_file_cache_serialize_class(zval                     *zv,
 	zend_file_cache_serialize_hash(&ce->constants_table, script, info, buf, zend_file_cache_serialize_class_constant);
 	SERIALIZE_STR(ce->info.user.filename);
 	SERIALIZE_STR(ce->info.user.doc_comment);
+	SERIALIZE_ATTRIBUTES(ce->info.user.attributes);
 	zend_file_cache_serialize_hash(&ce->properties_info, script, info, buf, zend_file_cache_serialize_prop_info);
 
 	if (ce->properties_info_table) {
@@ -1139,6 +1165,7 @@ static void zend_file_cache_unserialize_op_array(zend_op_array           *op_arr
 		UNSERIALIZE_PTR(op_array->live_range);
 		UNSERIALIZE_PTR(op_array->scope);
 		UNSERIALIZE_STR(op_array->doc_comment);
+		UNSERIALIZE_ATTRIBUTES(op_array->attributes);
 		UNSERIALIZE_PTR(op_array->try_catch_array);
 		UNSERIALIZE_PTR(op_array->prototype);
 		return;
@@ -1254,6 +1281,7 @@ static void zend_file_cache_unserialize_op_array(zend_op_array           *op_arr
 		UNSERIALIZE_PTR(op_array->live_range);
 		UNSERIALIZE_PTR(op_array->scope);
 		UNSERIALIZE_STR(op_array->doc_comment);
+		UNSERIALIZE_ATTRIBUTES(op_array->attributes);
 		UNSERIALIZE_PTR(op_array->try_catch_array);
 		UNSERIALIZE_PTR(op_array->prototype);
 
@@ -1307,6 +1335,7 @@ static void zend_file_cache_unserialize_prop_info(zval                    *zv,
 			if (prop->doc_comment) {
 				UNSERIALIZE_STR(prop->doc_comment);
 			}
+			UNSERIALIZE_ATTRIBUTES(prop->attributes);
 			zend_file_cache_unserialize_type(&prop->type, script, buf);
 		}
 	}
@@ -1331,6 +1360,7 @@ static void zend_file_cache_unserialize_class_constant(zval                    *
 			if (c->doc_comment) {
 				UNSERIALIZE_STR(c->doc_comment);
 			}
+			UNSERIALIZE_ATTRIBUTES(c->attributes);
 		}
 	}
 }
@@ -1385,6 +1415,7 @@ static void zend_file_cache_unserialize_class(zval                    *zv,
 			script, buf, zend_file_cache_unserialize_class_constant, NULL);
 	UNSERIALIZE_STR(ce->info.user.filename);
 	UNSERIALIZE_STR(ce->info.user.doc_comment);
+	UNSERIALIZE_ATTRIBUTES(ce->info.user.attributes);
 	zend_file_cache_unserialize_hash(&ce->properties_info,
 			script, buf, zend_file_cache_unserialize_prop_info, NULL);
 

--- a/ext/opcache/zend_persist_calc.c
+++ b/ext/opcache/zend_persist_calc.c
@@ -53,6 +53,21 @@
 		} \
 	} while (0)
 
+#define zend_persist_attributes_calc(attr) do { \
+	if (!zend_shared_alloc_get_xlat_entry(attr)) { \
+		Bucket *p; \
+		zend_shared_alloc_register_xlat_entry((attr), (attr)); \
+		ADD_SIZE(sizeof(HashTable)); \
+		zend_hash_persist_calc(attr); \
+		ZEND_HASH_FOREACH_BUCKET((attr), p) { \
+			if (p->key) { \
+				ADD_INTERNED_STRING(p->key); \
+			} \
+			zend_persist_zval_calc(&p->val); \
+		} ZEND_HASH_FOREACH_END(); \
+	} \
+} while (0)
+
 static void zend_persist_zval_calc(zval *z);
 
 static void zend_hash_persist_calc(HashTable *ht)
@@ -249,6 +264,10 @@ static void zend_persist_op_array_calc_ex(zend_op_array *op_array)
 		ADD_STRING(op_array->doc_comment);
 	}
 
+	if (op_array->attributes) {
+		zend_persist_attributes_calc(op_array->attributes);
+	}
+
 	if (op_array->try_catch_array) {
 		ADD_SIZE(sizeof(zend_try_catch_element) * op_array->last_try_catch);
 	}
@@ -325,6 +344,9 @@ static void zend_persist_property_info_calc(zval *zv)
 		if (ZCG(accel_directives).save_comments && prop->doc_comment) {
 			ADD_STRING(prop->doc_comment);
 		}
+		if (prop->attributes) {
+			zend_persist_attributes_calc(prop->attributes);
+		}
 	}
 }
 
@@ -338,6 +360,9 @@ static void zend_persist_class_constant_calc(zval *zv)
 		zend_persist_zval_calc(&c->value);
 		if (ZCG(accel_directives).save_comments && c->doc_comment) {
 			ADD_STRING(c->doc_comment);
+		}
+		if (c->attributes) {
+			zend_persist_attributes_calc(c->attributes);
 		}
 	}
 }
@@ -423,6 +448,9 @@ static void zend_persist_class_entry_calc(zval *zv)
 		}
 		if (ZCG(accel_directives).save_comments && ce->info.user.doc_comment) {
 			ADD_STRING(ce->info.user.doc_comment);
+		}
+		if (ce->info.user.attributes) {
+			zend_persist_attributes_calc(ce->info.user.attributes);
 		}
 
 		zend_hash_persist_calc(&ce->properties_info);

--- a/ext/reflection/php_reflection.c
+++ b/ext/reflection/php_reflection.c
@@ -6451,7 +6451,7 @@ ZEND_METHOD(ReflectionAttribute, getName)
 }
 /* }}} */
 
-static int import_attribute_value(zval *ret, zval *val, zend_class_entry *scope) /* {{{ */
+static zend_always_inline int import_attribute_value(zval *ret, zval *val, zend_class_entry *scope) /* {{{ */
 {
 	if (Z_TYPE_P(val) == IS_CONSTANT_AST) {
 		*ret = *val;

--- a/ext/reflection/php_reflection.c
+++ b/ext/reflection/php_reflection.c
@@ -6647,9 +6647,9 @@ static void attribute_ctor_cleanup(zval *obj, zval *args, uint32_t argc) /* {{{ 
 }
 /* }}} */
 
-/* {{{ proto public string ReflectionAttribute::getAsObject()
+/* {{{ proto public string ReflectionAttribute::newInstance()
  *	   Returns the attribute as an object */
-ZEND_METHOD(ReflectionAttribute, getAsObject)
+ZEND_METHOD(ReflectionAttribute, newInstance)
 {
 	reflection_object *intern;
 	attribute_reference *attr;

--- a/ext/reflection/php_reflection.c
+++ b/ext/reflection/php_reflection.c
@@ -1765,7 +1765,7 @@ ZEND_METHOD(ReflectionFunctionAbstract, getDocComment)
 }
 /* }}} */
 
-/* {{{ proto public array ReflectionFunction::getAttributes()
+/* {{{ proto public array ReflectionFunction::getAttributes([ string name, int flags ])
    Returns the attributes of this function */
 ZEND_METHOD(ReflectionFunctionAbstract, getAttributes)
 {
@@ -2711,7 +2711,7 @@ ZEND_METHOD(ReflectionParameter, canBePassedByValue)
 }
 /* }}} */
 
-/* {{{ proto public bool ReflectionParameter::getAttributes(?string $name = null)
+/* {{{ proto public array ReflectionParameter::getAttributes([ string name, int flags ])
    Get parameter attributes. */
 ZEND_METHOD(ReflectionParameter, getAttributes)
 {
@@ -2731,7 +2731,7 @@ ZEND_METHOD(ReflectionParameter, getAttributes)
 	reflect_attributes(INTERNAL_FUNCTION_PARAM_PASSTHRU, attributes, param->offset + 1, scope);
 }
 
-/* {{{ proto public bool ReflectionParameter::getPosition()
+/* {{{ proto public int ReflectionParameter::getPosition()
    Returns whether this parameter is an optional parameter */
 ZEND_METHOD(ReflectionParameter, getPosition)
 {
@@ -3786,7 +3786,7 @@ ZEND_METHOD(ReflectionClassConstant, getDocComment)
 }
 /* }}} */
 
-/* {{{ proto public array ReflectionClassConstant::getAttributes()
+/* {{{ proto public array ReflectionClassConstant::getAttributes([ string name, int flags ])
    Returns the attributes of this constant */
 ZEND_METHOD(ReflectionClassConstant, getAttributes)
 {
@@ -4174,7 +4174,7 @@ ZEND_METHOD(ReflectionClass, getDocComment)
 }
 /* }}} */
 
-/* {{{ proto public array ReflectionClass::getAttributes()
+/* {{{ proto public array ReflectionClass::getAttributes([ string name, int flags ])
    Returns the attributes for this class */
 ZEND_METHOD(ReflectionClass, getAttributes)
 {
@@ -5695,7 +5695,7 @@ ZEND_METHOD(ReflectionProperty, getDocComment)
 }
 /* }}} */
 
-/* {{{ proto public array ReflectionProperty::getAttributes()
+/* {{{ proto public array ReflectionProperty::getAttributes([ string name, int flags ])
    Returns the attributes of this property */
 ZEND_METHOD(ReflectionProperty, getAttributes)
 {
@@ -6467,7 +6467,7 @@ static zend_always_inline int import_attribute_value(zval *ret, zval *val, zend_
 }
 /* }}} */
 
-/* {{{ proto public string ReflectionAttribute::getArguments()
+/* {{{ proto public array ReflectionAttribute::getArguments()
  *	   Returns the arguments passed to the attribute */
 ZEND_METHOD(ReflectionAttribute, getArguments)
 {
@@ -6562,7 +6562,7 @@ static void attribute_ctor_cleanup(zval *obj, zval *args, uint32_t argc) /* {{{ 
 }
 /* }}} */
 
-/* {{{ proto public string ReflectionAttribute::newInstance()
+/* {{{ proto public object ReflectionAttribute::newInstance()
  *	   Returns the attribute as an object */
 ZEND_METHOD(ReflectionAttribute, newInstance)
 {
@@ -6587,10 +6587,10 @@ ZEND_METHOD(ReflectionAttribute, newInstance)
 		RETURN_THROWS();
 	}
 
-	if (ce->type == ZEND_USER_CLASS && !zend_has_attribute_str(ce->info.user.attributes, ZEND_STRL("phpattribute"), 0)) {
+	if (ce->type == ZEND_USER_CLASS && !zend_get_attribute_str(ce->info.user.attributes, ZEND_STRL("phpattribute"), 0)) {
 		zend_throw_error(NULL, "Attempting to use class '%s' as attribute that does not have <<PhpAttribute>>.", ZSTR_VAL(attr->data->name));
 		RETURN_THROWS();
-	} else if (ce->type == ZEND_INTERNAL_CLASS && zend_hash_exists(&zend_attributes_internal_validators, attr->data->lcname) == 0) {
+	} else if (ce->type == ZEND_INTERNAL_CLASS && !zend_attribute_get_validator(attr->data->lcname)) {
 		zend_throw_error(NULL, "Attempting to use internal class '%s' as attribute that does not have <<PhpCompilerAttribute>>.", ZSTR_VAL(attr->data->name));
 		RETURN_THROWS();
 	}

--- a/ext/reflection/php_reflection.h
+++ b/ext/reflection/php_reflection.h
@@ -42,6 +42,7 @@ extern PHPAPI zend_class_entry *reflection_property_ptr;
 extern PHPAPI zend_class_entry *reflection_extension_ptr;
 extern PHPAPI zend_class_entry *reflection_zend_extension_ptr;
 extern PHPAPI zend_class_entry *reflection_reference_ptr;
+extern PHPAPI zend_class_entry *reflection_attribute_ptr;
 
 PHPAPI void zend_reflection_class_factory(zend_class_entry *ce, zval *object);
 

--- a/ext/reflection/php_reflection.stub.php
+++ b/ext/reflection/php_reflection.stub.php
@@ -541,7 +541,7 @@ class ReflectionParameter implements Reflector
 
     /** @return bool */
     public function isVariadic() {}
-    
+
     /** @return ReflectionAttribute[] */
     public function getAttributes(?string $name = null, int $flags = 0) {}
 }
@@ -656,7 +656,7 @@ final class ReflectionAttribute
 {
     public function getName(): string {}
     public function getArguments(): array {}
-    public function getAsObject(): object {}
+    public function newInstance(): object {}
 
     private function __clone() {}
 

--- a/ext/reflection/php_reflection.stub.php
+++ b/ext/reflection/php_reflection.stub.php
@@ -95,6 +95,9 @@ abstract class ReflectionFunctionAbstract implements Reflector
 
     /** @return ReflectionType|null */
     public function getReturnType() {}
+
+    /** @return ReflectionAttribute[] */
+    public function getAttributes(?string $name = null, int $flags = 0) {}
 }
 
 class ReflectionFunction extends ReflectionFunctionAbstract
@@ -360,6 +363,9 @@ class ReflectionClass implements Reflector
 
     /** @return string */
     public function getShortName() {}
+
+    /** @return ReflectionAttribute[] */
+    public function getAttributes(?string $name = null, int $flags = 0) {}
 }
 
 class ReflectionObject extends ReflectionClass
@@ -426,6 +432,9 @@ class ReflectionProperty implements Reflector
 
     /** @return mixed */
     public function getDefaultValue() {}
+
+    /** @return ReflectionAttribute[] */
+    public function getAttributes(?string $name = null, int $flags = 0) {}
 }
 
 class ReflectionClassConstant implements Reflector
@@ -461,6 +470,9 @@ class ReflectionClassConstant implements Reflector
 
     /** @return string|false */
     public function getDocComment() {}
+
+    /** @return ReflectionAttribute[] */
+    public function getAttributes(?string $name = null, int $flags = 0) {}
 }
 
 class ReflectionParameter implements Reflector
@@ -529,6 +541,9 @@ class ReflectionParameter implements Reflector
 
     /** @return bool */
     public function isVariadic() {}
+    
+    /** @return ReflectionAttribute[] */
+    public function getAttributes(?string $name = null, int $flags = 0) {}
 }
 
 abstract class ReflectionType implements Stringable
@@ -632,6 +647,17 @@ final class ReflectionReference
     public function getId(): string {}
 
     /** @alias ReflectionClass::__clone */
+    private function __clone() {}
+
+    private function __construct() {}
+}
+
+final class ReflectionAttribute
+{
+    public function getName(): string {}
+    public function getArguments(): array {}
+    public function getAsObject(): object {}
+
     private function __clone() {}
 
     private function __construct() {}

--- a/ext/reflection/php_reflection_arginfo.h
+++ b/ext/reflection/php_reflection_arginfo.h
@@ -472,7 +472,7 @@ ZEND_END_ARG_INFO()
 
 #define arginfo_class_ReflectionAttribute_getArguments arginfo_class_ReflectionUnionType_getTypes
 
-ZEND_BEGIN_ARG_WITH_RETURN_TYPE_INFO_EX(arginfo_class_ReflectionAttribute_getAsObject, 0, 0, IS_OBJECT, 0)
+ZEND_BEGIN_ARG_WITH_RETURN_TYPE_INFO_EX(arginfo_class_ReflectionAttribute_newInstance, 0, 0, IS_OBJECT, 0)
 ZEND_END_ARG_INFO()
 
 #define arginfo_class_ReflectionAttribute___clone arginfo_class_ReflectionFunctionAbstract___clone
@@ -673,7 +673,7 @@ ZEND_METHOD(ReflectionReference, getId);
 ZEND_METHOD(ReflectionReference, __construct);
 ZEND_METHOD(ReflectionAttribute, getName);
 ZEND_METHOD(ReflectionAttribute, getArguments);
-ZEND_METHOD(ReflectionAttribute, getAsObject);
+ZEND_METHOD(ReflectionAttribute, newInstance);
 ZEND_METHOD(ReflectionAttribute, __clone);
 ZEND_METHOD(ReflectionAttribute, __construct);
 
@@ -971,7 +971,7 @@ static const zend_function_entry class_ReflectionReference_methods[] = {
 static const zend_function_entry class_ReflectionAttribute_methods[] = {
 	ZEND_ME(ReflectionAttribute, getName, arginfo_class_ReflectionAttribute_getName, ZEND_ACC_PUBLIC)
 	ZEND_ME(ReflectionAttribute, getArguments, arginfo_class_ReflectionAttribute_getArguments, ZEND_ACC_PUBLIC)
-	ZEND_ME(ReflectionAttribute, getAsObject, arginfo_class_ReflectionAttribute_getAsObject, ZEND_ACC_PUBLIC)
+	ZEND_ME(ReflectionAttribute, newInstance, arginfo_class_ReflectionAttribute_newInstance, ZEND_ACC_PUBLIC)
 	ZEND_ME(ReflectionAttribute, __clone, arginfo_class_ReflectionAttribute___clone, ZEND_ACC_PRIVATE)
 	ZEND_ME(ReflectionAttribute, __construct, arginfo_class_ReflectionAttribute___construct, ZEND_ACC_PRIVATE)
 	ZEND_FE_END

--- a/ext/reflection/php_reflection_arginfo.h
+++ b/ext/reflection/php_reflection_arginfo.h
@@ -57,6 +57,11 @@ ZEND_END_ARG_INFO()
 
 #define arginfo_class_ReflectionFunctionAbstract_getReturnType arginfo_class_ReflectionFunctionAbstract___clone
 
+ZEND_BEGIN_ARG_INFO_EX(arginfo_class_ReflectionFunctionAbstract_getAttributes, 0, 0, 0)
+	ZEND_ARG_TYPE_INFO_WITH_DEFAULT_VALUE(0, name, IS_STRING, 1, "null")
+	ZEND_ARG_TYPE_INFO_WITH_DEFAULT_VALUE(0, flags, IS_LONG, 0, "0")
+ZEND_END_ARG_INFO()
+
 ZEND_BEGIN_ARG_INFO_EX(arginfo_class_ReflectionFunction___construct, 0, 0, 1)
 	ZEND_ARG_INFO(0, name)
 ZEND_END_ARG_INFO()
@@ -267,6 +272,8 @@ ZEND_END_ARG_INFO()
 
 #define arginfo_class_ReflectionClass_getShortName arginfo_class_ReflectionFunctionAbstract___clone
 
+#define arginfo_class_ReflectionClass_getAttributes arginfo_class_ReflectionFunctionAbstract_getAttributes
+
 ZEND_BEGIN_ARG_INFO_EX(arginfo_class_ReflectionObject___construct, 0, 0, 1)
 	ZEND_ARG_TYPE_INFO(0, argument, IS_OBJECT, 0)
 ZEND_END_ARG_INFO()
@@ -320,6 +327,8 @@ ZEND_END_ARG_INFO()
 
 #define arginfo_class_ReflectionProperty_getDefaultValue arginfo_class_ReflectionFunctionAbstract___clone
 
+#define arginfo_class_ReflectionProperty_getAttributes arginfo_class_ReflectionFunctionAbstract_getAttributes
+
 #define arginfo_class_ReflectionClassConstant___clone arginfo_class_ReflectionFunctionAbstract___clone
 
 #define arginfo_class_ReflectionClassConstant___construct arginfo_class_ReflectionProperty___construct
@@ -341,6 +350,8 @@ ZEND_END_ARG_INFO()
 #define arginfo_class_ReflectionClassConstant_getDeclaringClass arginfo_class_ReflectionFunctionAbstract___clone
 
 #define arginfo_class_ReflectionClassConstant_getDocComment arginfo_class_ReflectionFunctionAbstract___clone
+
+#define arginfo_class_ReflectionClassConstant_getAttributes arginfo_class_ReflectionFunctionAbstract_getAttributes
 
 #define arginfo_class_ReflectionParameter___clone arginfo_class_ReflectionFunctionAbstract___clone
 
@@ -386,6 +397,8 @@ ZEND_END_ARG_INFO()
 #define arginfo_class_ReflectionParameter_getDefaultValueConstantName arginfo_class_ReflectionFunctionAbstract___clone
 
 #define arginfo_class_ReflectionParameter_isVariadic arginfo_class_ReflectionFunctionAbstract___clone
+
+#define arginfo_class_ReflectionParameter_getAttributes arginfo_class_ReflectionFunctionAbstract_getAttributes
 
 #define arginfo_class_ReflectionType___clone arginfo_class_ReflectionFunctionAbstract___clone
 
@@ -455,6 +468,17 @@ ZEND_END_ARG_INFO()
 
 #define arginfo_class_ReflectionReference___construct arginfo_class_ReflectionFunctionAbstract___clone
 
+#define arginfo_class_ReflectionAttribute_getName arginfo_class_ReflectionFunction___toString
+
+#define arginfo_class_ReflectionAttribute_getArguments arginfo_class_ReflectionUnionType_getTypes
+
+ZEND_BEGIN_ARG_WITH_RETURN_TYPE_INFO_EX(arginfo_class_ReflectionAttribute_getAsObject, 0, 0, IS_OBJECT, 0)
+ZEND_END_ARG_INFO()
+
+#define arginfo_class_ReflectionAttribute___clone arginfo_class_ReflectionFunctionAbstract___clone
+
+#define arginfo_class_ReflectionAttribute___construct arginfo_class_ReflectionFunctionAbstract___clone
+
 
 ZEND_METHOD(Reflection, getModifierNames);
 ZEND_METHOD(ReflectionClass, __clone);
@@ -483,6 +507,7 @@ ZEND_METHOD(ReflectionFunctionAbstract, getStaticVariables);
 ZEND_METHOD(ReflectionFunctionAbstract, returnsReference);
 ZEND_METHOD(ReflectionFunctionAbstract, hasReturnType);
 ZEND_METHOD(ReflectionFunctionAbstract, getReturnType);
+ZEND_METHOD(ReflectionFunctionAbstract, getAttributes);
 ZEND_METHOD(ReflectionFunction, __construct);
 ZEND_METHOD(ReflectionFunction, __toString);
 ZEND_METHOD(ReflectionFunction, isDisabled);
@@ -564,6 +589,7 @@ ZEND_METHOD(ReflectionClass, getExtensionName);
 ZEND_METHOD(ReflectionClass, inNamespace);
 ZEND_METHOD(ReflectionClass, getNamespaceName);
 ZEND_METHOD(ReflectionClass, getShortName);
+ZEND_METHOD(ReflectionClass, getAttributes);
 ZEND_METHOD(ReflectionObject, __construct);
 ZEND_METHOD(ReflectionProperty, __construct);
 ZEND_METHOD(ReflectionProperty, __toString);
@@ -584,6 +610,7 @@ ZEND_METHOD(ReflectionProperty, getType);
 ZEND_METHOD(ReflectionProperty, hasType);
 ZEND_METHOD(ReflectionProperty, hasDefaultValue);
 ZEND_METHOD(ReflectionProperty, getDefaultValue);
+ZEND_METHOD(ReflectionProperty, getAttributes);
 ZEND_METHOD(ReflectionClassConstant, __construct);
 ZEND_METHOD(ReflectionClassConstant, __toString);
 ZEND_METHOD(ReflectionClassConstant, getName);
@@ -594,6 +621,7 @@ ZEND_METHOD(ReflectionClassConstant, isProtected);
 ZEND_METHOD(ReflectionClassConstant, getModifiers);
 ZEND_METHOD(ReflectionClassConstant, getDeclaringClass);
 ZEND_METHOD(ReflectionClassConstant, getDocComment);
+ZEND_METHOD(ReflectionClassConstant, getAttributes);
 ZEND_METHOD(ReflectionParameter, __construct);
 ZEND_METHOD(ReflectionParameter, __toString);
 ZEND_METHOD(ReflectionParameter, getName);
@@ -614,6 +642,7 @@ ZEND_METHOD(ReflectionParameter, getDefaultValue);
 ZEND_METHOD(ReflectionParameter, isDefaultValueConstant);
 ZEND_METHOD(ReflectionParameter, getDefaultValueConstantName);
 ZEND_METHOD(ReflectionParameter, isVariadic);
+ZEND_METHOD(ReflectionParameter, getAttributes);
 ZEND_METHOD(ReflectionType, allowsNull);
 ZEND_METHOD(ReflectionType, __toString);
 ZEND_METHOD(ReflectionNamedType, getName);
@@ -642,6 +671,11 @@ ZEND_METHOD(ReflectionZendExtension, getCopyright);
 ZEND_METHOD(ReflectionReference, fromArrayElement);
 ZEND_METHOD(ReflectionReference, getId);
 ZEND_METHOD(ReflectionReference, __construct);
+ZEND_METHOD(ReflectionAttribute, getName);
+ZEND_METHOD(ReflectionAttribute, getArguments);
+ZEND_METHOD(ReflectionAttribute, getAsObject);
+ZEND_METHOD(ReflectionAttribute, __clone);
+ZEND_METHOD(ReflectionAttribute, __construct);
 
 
 static const zend_function_entry class_ReflectionException_methods[] = {
@@ -687,6 +721,7 @@ static const zend_function_entry class_ReflectionFunctionAbstract_methods[] = {
 	ZEND_ME(ReflectionFunctionAbstract, returnsReference, arginfo_class_ReflectionFunctionAbstract_returnsReference, ZEND_ACC_PUBLIC)
 	ZEND_ME(ReflectionFunctionAbstract, hasReturnType, arginfo_class_ReflectionFunctionAbstract_hasReturnType, ZEND_ACC_PUBLIC)
 	ZEND_ME(ReflectionFunctionAbstract, getReturnType, arginfo_class_ReflectionFunctionAbstract_getReturnType, ZEND_ACC_PUBLIC)
+	ZEND_ME(ReflectionFunctionAbstract, getAttributes, arginfo_class_ReflectionFunctionAbstract_getAttributes, ZEND_ACC_PUBLIC)
 	ZEND_FE_END
 };
 
@@ -790,6 +825,7 @@ static const zend_function_entry class_ReflectionClass_methods[] = {
 	ZEND_ME(ReflectionClass, inNamespace, arginfo_class_ReflectionClass_inNamespace, ZEND_ACC_PUBLIC)
 	ZEND_ME(ReflectionClass, getNamespaceName, arginfo_class_ReflectionClass_getNamespaceName, ZEND_ACC_PUBLIC)
 	ZEND_ME(ReflectionClass, getShortName, arginfo_class_ReflectionClass_getShortName, ZEND_ACC_PUBLIC)
+	ZEND_ME(ReflectionClass, getAttributes, arginfo_class_ReflectionClass_getAttributes, ZEND_ACC_PUBLIC)
 	ZEND_FE_END
 };
 
@@ -821,6 +857,7 @@ static const zend_function_entry class_ReflectionProperty_methods[] = {
 	ZEND_ME(ReflectionProperty, hasType, arginfo_class_ReflectionProperty_hasType, ZEND_ACC_PUBLIC)
 	ZEND_ME(ReflectionProperty, hasDefaultValue, arginfo_class_ReflectionProperty_hasDefaultValue, ZEND_ACC_PUBLIC)
 	ZEND_ME(ReflectionProperty, getDefaultValue, arginfo_class_ReflectionProperty_getDefaultValue, ZEND_ACC_PUBLIC)
+	ZEND_ME(ReflectionProperty, getAttributes, arginfo_class_ReflectionProperty_getAttributes, ZEND_ACC_PUBLIC)
 	ZEND_FE_END
 };
 
@@ -837,6 +874,7 @@ static const zend_function_entry class_ReflectionClassConstant_methods[] = {
 	ZEND_ME(ReflectionClassConstant, getModifiers, arginfo_class_ReflectionClassConstant_getModifiers, ZEND_ACC_PUBLIC)
 	ZEND_ME(ReflectionClassConstant, getDeclaringClass, arginfo_class_ReflectionClassConstant_getDeclaringClass, ZEND_ACC_PUBLIC)
 	ZEND_ME(ReflectionClassConstant, getDocComment, arginfo_class_ReflectionClassConstant_getDocComment, ZEND_ACC_PUBLIC)
+	ZEND_ME(ReflectionClassConstant, getAttributes, arginfo_class_ReflectionClassConstant_getAttributes, ZEND_ACC_PUBLIC)
 	ZEND_FE_END
 };
 
@@ -863,6 +901,7 @@ static const zend_function_entry class_ReflectionParameter_methods[] = {
 	ZEND_ME(ReflectionParameter, isDefaultValueConstant, arginfo_class_ReflectionParameter_isDefaultValueConstant, ZEND_ACC_PUBLIC)
 	ZEND_ME(ReflectionParameter, getDefaultValueConstantName, arginfo_class_ReflectionParameter_getDefaultValueConstantName, ZEND_ACC_PUBLIC)
 	ZEND_ME(ReflectionParameter, isVariadic, arginfo_class_ReflectionParameter_isVariadic, ZEND_ACC_PUBLIC)
+	ZEND_ME(ReflectionParameter, getAttributes, arginfo_class_ReflectionParameter_getAttributes, ZEND_ACC_PUBLIC)
 	ZEND_FE_END
 };
 
@@ -925,5 +964,15 @@ static const zend_function_entry class_ReflectionReference_methods[] = {
 	ZEND_ME(ReflectionReference, getId, arginfo_class_ReflectionReference_getId, ZEND_ACC_PUBLIC)
 	ZEND_MALIAS(ReflectionClass, __clone, __clone, arginfo_class_ReflectionReference___clone, ZEND_ACC_PRIVATE)
 	ZEND_ME(ReflectionReference, __construct, arginfo_class_ReflectionReference___construct, ZEND_ACC_PRIVATE)
+	ZEND_FE_END
+};
+
+
+static const zend_function_entry class_ReflectionAttribute_methods[] = {
+	ZEND_ME(ReflectionAttribute, getName, arginfo_class_ReflectionAttribute_getName, ZEND_ACC_PUBLIC)
+	ZEND_ME(ReflectionAttribute, getArguments, arginfo_class_ReflectionAttribute_getArguments, ZEND_ACC_PUBLIC)
+	ZEND_ME(ReflectionAttribute, getAsObject, arginfo_class_ReflectionAttribute_getAsObject, ZEND_ACC_PUBLIC)
+	ZEND_ME(ReflectionAttribute, __clone, arginfo_class_ReflectionAttribute___clone, ZEND_ACC_PRIVATE)
+	ZEND_ME(ReflectionAttribute, __construct, arginfo_class_ReflectionAttribute___construct, ZEND_ACC_PRIVATE)
 	ZEND_FE_END
 };

--- a/ext/reflection/tests/ReflectionClass_toString_001.phpt
+++ b/ext/reflection/tests/ReflectionClass_toString_001.phpt
@@ -27,7 +27,7 @@ Class [ <internal:Reflection> class ReflectionClass implements Reflector, String
     Property [ public $name = '' ]
   }
 
-  - Methods [53] {
+  - Methods [54] {
     Method [ <internal:Reflection> final private method __clone ] {
 
       - Parameters [0] {
@@ -363,6 +363,14 @@ Class [ <internal:Reflection> class ReflectionClass implements Reflector, String
     Method [ <internal:Reflection> public method getShortName ] {
 
       - Parameters [0] {
+      }
+    }
+
+    Method [ <internal:Reflection> public method getAttributes ] {
+
+      - Parameters [2] {
+        Parameter #0 [ <optional> ?string $name = null ]
+        Parameter #1 [ <optional> int $flags = 0 ]
       }
     }
   }

--- a/ext/reflection/tests/ReflectionExtension_getClasses_basic.phpt
+++ b/ext/reflection/tests/ReflectionExtension_getClasses_basic.phpt
@@ -8,7 +8,7 @@ $ext = new ReflectionExtension('reflection');
 var_dump($ext->getClasses());
 ?>
 --EXPECT--
-array(18) {
+array(19) {
   ["ReflectionException"]=>
   object(ReflectionClass)#2 (1) {
     ["name"]=>
@@ -98,5 +98,10 @@ array(18) {
   object(ReflectionClass)#19 (1) {
     ["name"]=>
     string(19) "ReflectionReference"
+  }
+  ["ReflectionAttribute"]=>
+  object(ReflectionClass)#20 (1) {
+    ["name"]=>
+    string(19) "ReflectionAttribute"
   }
 }

--- a/ext/tokenizer/tokenizer.c
+++ b/ext/tokenizer/tokenizer.c
@@ -266,22 +266,22 @@ PHP_MINIT_FUNCTION(tokenizer)
 	zend_class_implements(php_token_ce, 1, zend_ce_stringable);
 
 	name = zend_string_init("id", sizeof("id") - 1, 1);
-	zend_declare_typed_property(php_token_ce, name, &default_val, ZEND_ACC_PUBLIC, NULL,
+	zend_declare_typed_property(php_token_ce, name, &default_val, ZEND_ACC_PUBLIC, NULL, NULL,
 		(zend_type) ZEND_TYPE_INIT_MASK(MAY_BE_LONG));
 	zend_string_release(name);
 
 	name = zend_string_init("text", sizeof("text") - 1, 1);
-	zend_declare_typed_property(php_token_ce, name, &default_val, ZEND_ACC_PUBLIC, NULL,
+	zend_declare_typed_property(php_token_ce, name, &default_val, ZEND_ACC_PUBLIC, NULL, NULL,
 		(zend_type) ZEND_TYPE_INIT_MASK(MAY_BE_STRING));
 	zend_string_release(name);
 
 	name = zend_string_init("line", sizeof("line") - 1, 1);
-	zend_declare_typed_property(php_token_ce, name, &default_val, ZEND_ACC_PUBLIC, NULL,
+	zend_declare_typed_property(php_token_ce, name, &default_val, ZEND_ACC_PUBLIC, NULL, NULL,
 		(zend_type) ZEND_TYPE_INIT_MASK(MAY_BE_LONG));
 	zend_string_release(name);
 
 	name = zend_string_init("pos", sizeof("pos") - 1, 1);
-	zend_declare_typed_property(php_token_ce, name, &default_val, ZEND_ACC_PUBLIC, NULL,
+	zend_declare_typed_property(php_token_ce, name, &default_val, ZEND_ACC_PUBLIC, NULL, NULL,
 		(zend_type) ZEND_TYPE_INIT_MASK(MAY_BE_LONG));
 	zend_string_release(name);
 

--- a/ext/zend_test/test.c
+++ b/ext/zend_test/test.c
@@ -217,7 +217,7 @@ PHP_MINIT_FUNCTION(zend_test)
 		zval val;
 		ZVAL_LONG(&val, 123);
 		zend_declare_typed_property(
-			zend_test_class, name, &val, ZEND_ACC_PUBLIC, NULL,
+			zend_test_class, name, &val, ZEND_ACC_PUBLIC, NULL, NULL,
 			(zend_type) ZEND_TYPE_INIT_CODE(IS_LONG, 0, 0));
 		zend_string_release(name);
 	}
@@ -228,7 +228,7 @@ PHP_MINIT_FUNCTION(zend_test)
 		zval val;
 		ZVAL_NULL(&val);
 		zend_declare_typed_property(
-			zend_test_class, name, &val, ZEND_ACC_PUBLIC, NULL,
+			zend_test_class, name, &val, ZEND_ACC_PUBLIC, NULL, NULL,
 			(zend_type) ZEND_TYPE_INIT_CLASS(class_name, 1, 0));
 		zend_string_release(name);
 	}
@@ -244,7 +244,7 @@ PHP_MINIT_FUNCTION(zend_test)
 		zend_type type = ZEND_TYPE_INIT_PTR(type_list, _ZEND_TYPE_LIST_BIT, 1, 0);
 		zval val;
 		ZVAL_NULL(&val);
-		zend_declare_typed_property(zend_test_class, name, &val, ZEND_ACC_PUBLIC, NULL, type);
+		zend_declare_typed_property(zend_test_class, name, &val, ZEND_ACC_PUBLIC, NULL, NULL, type);
 		zend_string_release(name);
 	}
 
@@ -253,7 +253,7 @@ PHP_MINIT_FUNCTION(zend_test)
 		zval val;
 		ZVAL_LONG(&val, 123);
 		zend_declare_typed_property(
-			zend_test_class, name, &val, ZEND_ACC_PUBLIC | ZEND_ACC_STATIC, NULL,
+			zend_test_class, name, &val, ZEND_ACC_PUBLIC | ZEND_ACC_STATIC, NULL, NULL,
 			(zend_type) ZEND_TYPE_INIT_CODE(IS_LONG, 0, 0));
 		zend_string_release(name);
 	}

--- a/ext/zip/php_zip.c
+++ b/ext/zip/php_zip.c
@@ -851,7 +851,7 @@ static void php_zip_register_prop_handler(HashTable *prop_handler, char *name, z
 
 	/* Register for reflection */
 	ZVAL_NULL(&tmp);
-	zend_declare_property_ex(zip_class_entry, str, &tmp, ZEND_ACC_PUBLIC, NULL);
+	zend_declare_property_ex(zip_class_entry, str, &tmp, ZEND_ACC_PUBLIC, NULL, NULL);
 	zend_string_release_ex(str, 1);
 }
 /* }}} */

--- a/win32/build/config.w32
+++ b/win32/build/config.w32
@@ -230,7 +230,7 @@ ADD_SOURCES("Zend", "zend_language_parser.c zend_language_scanner.c \
 	zend_execute_API.c zend_highlight.c \
 	zend_llist.c zend_vm_opcodes.c zend_opcode.c zend_operators.c zend_ptr_stack.c \
 	zend_stack.c zend_variables.c zend.c zend_API.c zend_extensions.c \
-	zend_hash.c zend_list.c zend_builtin_functions.c \
+	zend_hash.c zend_list.c zend_builtin_functions.c zend_attributes.c \
 	zend_ini.c zend_sort.c zend_multibyte.c zend_ts_hash.c \
 	zend_stream.c zend_iterators.c zend_interfaces.c zend_objects.c \
 	zend_object_handlers.c zend_objects_API.c \


### PR DESCRIPTION
Changes:

```php
/** @jit */
function foo() {}
```

To:

```php
use Opcache\Jit;

<<Jit>>
function foo() {}
```

In addition allows disabling the JIT for a function regardless of the selected JIT trigger:

```php
use Opcache\Jit;

<<Jit(false)>>
function foo() {} // this never gets jitted
```
Also changes the precedence of an attribute to be always higher than any other trigger definition, which means with `<<Jit(false)>>` you can prevent jitting even for the "on script load" or "on first execute" trigger and with `<<Jit(true)>>` you can always force jitting a function or method on profiling trigger modes.