### PR TITLE
Implement Opcache File Backend

### DIFF
--- a/Zend/tests/attributes/001_placement.phpt
+++ b/Zend/tests/attributes/001_placement.phpt
@@ -43,68 +43,83 @@ $sources = [
 ];
 
 foreach ($sources as $r) {
-    foreach ($r->getAttributes() as $attr) {
-        var_dump($attr->getName(), $attr->getArguments());
+	$attr = $r->getAttributes();
+	var_dump(count($attr));
+	
+    foreach ($attr as $a) {
+        var_dump($a->getName(), $a->getArguments());
     }
 }
 
 ?>
 --EXPECT--
+int(1)
 string(2) "A1"
 array(1) {
   [0]=>
   int(1)
 }
+int(1)
 string(2) "A1"
 array(1) {
   [0]=>
   int(2)
 }
+int(1)
 string(2) "A1"
 array(1) {
   [0]=>
   int(2)
 }
+int(1)
 string(2) "A1"
 array(1) {
   [0]=>
   int(3)
 }
+int(1)
 string(2) "A1"
 array(1) {
   [0]=>
   int(3)
 }
+int(1)
 string(2) "A1"
 array(1) {
   [0]=>
   int(4)
 }
+int(1)
 string(2) "A1"
 array(1) {
   [0]=>
   int(5)
 }
+int(1)
 string(2) "A1"
 array(1) {
   [0]=>
   int(6)
 }
+int(1)
 string(2) "A1"
 array(1) {
   [0]=>
   int(7)
 }
+int(1)
 string(2) "A1"
 array(1) {
   [0]=>
   int(8)
 }
+int(1)
 string(2) "A1"
 array(1) {
   [0]=>
   int(9)
 }
+int(1)
 string(2) "A1"
 array(1) {
   [0]=>

--- a/Zend/zend_compile.c
+++ b/Zend/zend_compile.c
@@ -5769,7 +5769,7 @@ static void zend_compile_attributes(HashTable *attributes, zend_ast *ast, uint32
 	ZEND_ASSERT(ast->kind == ZEND_AST_ATTRIBUTE_LIST);
 
 	for (i = 0; i < list->children; i++) {
-		zend_attribute *attr = zend_compile_attribute(list->child[i], 0);
+		zend_attribute *attr = zend_compile_attribute(list->child[i], offset);
 
 		// Validate internal attribute
 		zend_attributes_internal_validator validator = zend_hash_find_ptr(&zend_attributes_internal_validators, attr->lcname);


### PR DESCRIPTION
This PR implements storage of struct-based attributes in Opcache's file backend. In addition to that it fixes a bug with parameter attributes caused by failure to pass the offset during compilation... Please merge this as soon as possible. ;-)