### PR TITLE
Register Attributes Without Changes to ZEND APIs

### DIFF
--- a/Zend/zend_API.c
+++ b/Zend/zend_API.c
@@ -3515,7 +3515,7 @@ static zend_always_inline zend_bool is_persistent_class(zend_class_entry *ce) {
 		&& ce->info.internal.module->type == MODULE_PERSISTENT;
 }
 
-ZEND_API int zend_declare_typed_property(zend_class_entry *ce, zend_string *name, zval *property, int access_type, zend_string *doc_comment, zend_type type) /* {{{ */
+ZEND_API zend_property_info *zend_declare_typed_property(zend_class_entry *ce, zend_string *name, zval *property, int access_type, zend_string *doc_comment, zend_type type) /* {{{ */
 {
 	zend_property_info *property_info, *property_info_ptr;
 
@@ -3614,7 +3614,7 @@ ZEND_API int zend_declare_typed_property(zend_class_entry *ce, zend_string *name
 
 	zend_hash_update_ptr(&ce->properties_info, name, property_info);
 
-	return SUCCESS;
+	return property_info;
 }
 /* }}} */
 
@@ -3747,7 +3747,8 @@ ZEND_API int zend_try_assign_typed_ref_zval_ex(zend_reference *ref, zval *zv, ze
 
 ZEND_API int zend_declare_property_ex(zend_class_entry *ce, zend_string *name, zval *property, int access_type, zend_string *doc_comment) /* {{{ */
 {
-	return zend_declare_typed_property(ce, name, property, access_type, doc_comment, (zend_type) ZEND_TYPE_INIT_NONE(0));
+	zend_declare_typed_property(ce, name, property, access_type, doc_comment, (zend_type) ZEND_TYPE_INIT_NONE(0));
+	return SUCCESS;
 }
 /* }}} */
 
@@ -3814,7 +3815,7 @@ ZEND_API int zend_declare_property_stringl(zend_class_entry *ce, const char *nam
 }
 /* }}} */
 
-ZEND_API int zend_declare_class_constant_ex(zend_class_entry *ce, zend_string *name, zval *value, int access_type, zend_string *doc_comment) /* {{{ */
+ZEND_API zend_class_constant *zend_declare_class_constant_ex(zend_class_entry *ce, zend_string *name, zval *value, int access_type, zend_string *doc_comment) /* {{{ */
 {
 	zend_class_constant *c;
 
@@ -3852,14 +3853,12 @@ ZEND_API int zend_declare_class_constant_ex(zend_class_entry *ce, zend_string *n
 			"Cannot redefine class constant %s::%s", ZSTR_VAL(ce->name), ZSTR_VAL(name));
 	}
 
-	return SUCCESS;
+	return c;
 }
 /* }}} */
 
 ZEND_API int zend_declare_class_constant(zend_class_entry *ce, const char *name, size_t name_length, zval *value) /* {{{ */
 {
-	int ret;
-
 	zend_string *key;
 
 	if (ce->type == ZEND_INTERNAL_CLASS) {
@@ -3867,9 +3866,9 @@ ZEND_API int zend_declare_class_constant(zend_class_entry *ce, const char *name,
 	} else {
 		key = zend_string_init(name, name_length, 0);
 	}
-	ret = zend_declare_class_constant_ex(ce, key, value, ZEND_ACC_PUBLIC, NULL);
+	zend_declare_class_constant_ex(ce, key, value, ZEND_ACC_PUBLIC, NULL);
 	zend_string_release(key);
-	return ret;
+	return SUCCESS;
 }
 /* }}} */
 

--- a/Zend/zend_API.c
+++ b/Zend/zend_API.c
@@ -3515,7 +3515,7 @@ static zend_always_inline zend_bool is_persistent_class(zend_class_entry *ce) {
 		&& ce->info.internal.module->type == MODULE_PERSISTENT;
 }
 
-ZEND_API int zend_declare_typed_property(zend_class_entry *ce, zend_string *name, zval *property, int access_type, zend_string *doc_comment, HashTable *attributes, zend_type type) /* {{{ */
+ZEND_API int zend_declare_typed_property(zend_class_entry *ce, zend_string *name, zval *property, int access_type, zend_string *doc_comment, zend_type type) /* {{{ */
 {
 	zend_property_info *property_info, *property_info_ptr;
 
@@ -3608,7 +3608,7 @@ ZEND_API int zend_declare_typed_property(zend_class_entry *ce, zend_string *name
 	property_info->name = zend_new_interned_string(property_info->name);
 	property_info->flags = access_type;
 	property_info->doc_comment = doc_comment;
-	property_info->attributes = attributes;
+	property_info->attributes = NULL;
 	property_info->ce = ce;
 	property_info->type = type;
 
@@ -3745,16 +3745,16 @@ ZEND_API int zend_try_assign_typed_ref_zval_ex(zend_reference *ref, zval *zv, ze
 }
 /* }}} */
 
-ZEND_API int zend_declare_property_ex(zend_class_entry *ce, zend_string *name, zval *property, int access_type, zend_string *doc_comment, HashTable *attributes) /* {{{ */
+ZEND_API int zend_declare_property_ex(zend_class_entry *ce, zend_string *name, zval *property, int access_type, zend_string *doc_comment) /* {{{ */
 {
-	return zend_declare_typed_property(ce, name, property, access_type, doc_comment, attributes, (zend_type) ZEND_TYPE_INIT_NONE(0));
+	return zend_declare_typed_property(ce, name, property, access_type, doc_comment, (zend_type) ZEND_TYPE_INIT_NONE(0));
 }
 /* }}} */
 
 ZEND_API int zend_declare_property(zend_class_entry *ce, const char *name, size_t name_length, zval *property, int access_type) /* {{{ */
 {
 	zend_string *key = zend_string_init(name, name_length, is_persistent_class(ce));
-	int ret = zend_declare_property_ex(ce, key, property, access_type, NULL, NULL);
+	int ret = zend_declare_property_ex(ce, key, property, access_type, NULL);
 	zend_string_release(key);
 	return ret;
 }
@@ -3814,7 +3814,7 @@ ZEND_API int zend_declare_property_stringl(zend_class_entry *ce, const char *nam
 }
 /* }}} */
 
-ZEND_API int zend_declare_class_constant_ex(zend_class_entry *ce, zend_string *name, zval *value, int access_type, zend_string *doc_comment, HashTable *attributes) /* {{{ */
+ZEND_API int zend_declare_class_constant_ex(zend_class_entry *ce, zend_string *name, zval *value, int access_type, zend_string *doc_comment) /* {{{ */
 {
 	zend_class_constant *c;
 
@@ -3841,7 +3841,7 @@ ZEND_API int zend_declare_class_constant_ex(zend_class_entry *ce, zend_string *n
 	ZVAL_COPY_VALUE(&c->value, value);
 	Z_ACCESS_FLAGS(c->value) = access_type;
 	c->doc_comment = doc_comment;
-	c->attributes = attributes;
+	c->attributes = NULL;
 	c->ce = ce;
 	if (Z_TYPE_P(value) == IS_CONSTANT_AST) {
 		ce->ce_flags &= ~ZEND_ACC_CONSTANTS_UPDATED;
@@ -3867,7 +3867,7 @@ ZEND_API int zend_declare_class_constant(zend_class_entry *ce, const char *name,
 	} else {
 		key = zend_string_init(name, name_length, 0);
 	}
-	ret = zend_declare_class_constant_ex(ce, key, value, ZEND_ACC_PUBLIC, NULL, NULL);
+	ret = zend_declare_class_constant_ex(ce, key, value, ZEND_ACC_PUBLIC, NULL);
 	zend_string_release(key);
 	return ret;
 }

--- a/Zend/zend_API.h
+++ b/Zend/zend_API.h
@@ -351,7 +351,7 @@ ZEND_API zend_bool zend_make_callable(zval *callable, zend_string **callable_nam
 ZEND_API const char *zend_get_module_version(const char *module_name);
 ZEND_API int zend_get_module_started(const char *module_name);
 
-ZEND_API int zend_declare_typed_property(zend_class_entry *ce, zend_string *name, zval *property, int access_type, zend_string *doc_comment, zend_type type);
+ZEND_API zend_property_info *zend_declare_typed_property(zend_class_entry *ce, zend_string *name, zval *property, int access_type, zend_string *doc_comment, zend_type type);
 
 ZEND_API int zend_declare_property_ex(zend_class_entry *ce, zend_string *name, zval *property, int access_type, zend_string *doc_comment);
 ZEND_API int zend_declare_property(zend_class_entry *ce, const char *name, size_t name_length, zval *property, int access_type);
@@ -362,7 +362,7 @@ ZEND_API int zend_declare_property_double(zend_class_entry *ce, const char *name
 ZEND_API int zend_declare_property_string(zend_class_entry *ce, const char *name, size_t name_length, const char *value, int access_type);
 ZEND_API int zend_declare_property_stringl(zend_class_entry *ce, const char *name, size_t name_length, const char *value, size_t value_len, int access_type);
 
-ZEND_API int zend_declare_class_constant_ex(zend_class_entry *ce, zend_string *name, zval *value, int access_type, zend_string *doc_comment);
+ZEND_API zend_class_constant *zend_declare_class_constant_ex(zend_class_entry *ce, zend_string *name, zval *value, int access_type, zend_string *doc_comment);
 ZEND_API int zend_declare_class_constant(zend_class_entry *ce, const char *name, size_t name_length, zval *value);
 ZEND_API int zend_declare_class_constant_null(zend_class_entry *ce, const char *name, size_t name_length);
 ZEND_API int zend_declare_class_constant_long(zend_class_entry *ce, const char *name, size_t name_length, zend_long value);

--- a/Zend/zend_API.h
+++ b/Zend/zend_API.h
@@ -351,9 +351,9 @@ ZEND_API zend_bool zend_make_callable(zval *callable, zend_string **callable_nam
 ZEND_API const char *zend_get_module_version(const char *module_name);
 ZEND_API int zend_get_module_started(const char *module_name);
 
-ZEND_API int zend_declare_typed_property(zend_class_entry *ce, zend_string *name, zval *property, int access_type, zend_string *doc_comment, HashTable *attributes, zend_type type);
+ZEND_API int zend_declare_typed_property(zend_class_entry *ce, zend_string *name, zval *property, int access_type, zend_string *doc_comment, zend_type type);
 
-ZEND_API int zend_declare_property_ex(zend_class_entry *ce, zend_string *name, zval *property, int access_type, zend_string *doc_comment, HashTable *attributes);
+ZEND_API int zend_declare_property_ex(zend_class_entry *ce, zend_string *name, zval *property, int access_type, zend_string *doc_comment);
 ZEND_API int zend_declare_property(zend_class_entry *ce, const char *name, size_t name_length, zval *property, int access_type);
 ZEND_API int zend_declare_property_null(zend_class_entry *ce, const char *name, size_t name_length, int access_type);
 ZEND_API int zend_declare_property_bool(zend_class_entry *ce, const char *name, size_t name_length, zend_long value, int access_type);
@@ -362,7 +362,7 @@ ZEND_API int zend_declare_property_double(zend_class_entry *ce, const char *name
 ZEND_API int zend_declare_property_string(zend_class_entry *ce, const char *name, size_t name_length, const char *value, int access_type);
 ZEND_API int zend_declare_property_stringl(zend_class_entry *ce, const char *name, size_t name_length, const char *value, size_t value_len, int access_type);
 
-ZEND_API int zend_declare_class_constant_ex(zend_class_entry *ce, zend_string *name, zval *value, int access_type, zend_string *doc_comment, HashTable *attributes);
+ZEND_API int zend_declare_class_constant_ex(zend_class_entry *ce, zend_string *name, zval *value, int access_type, zend_string *doc_comment);
 ZEND_API int zend_declare_class_constant(zend_class_entry *ce, const char *name, size_t name_length, zval *value);
 ZEND_API int zend_declare_class_constant_null(zend_class_entry *ce, const char *name, size_t name_length);
 ZEND_API int zend_declare_class_constant_long(zend_class_entry *ce, const char *name, size_t name_length, zend_long value);

--- a/Zend/zend_attributes.c
+++ b/Zend/zend_attributes.c
@@ -103,7 +103,7 @@ ZEND_API zend_attribute *zend_add_attribute(HashTable **attributes, zend_bool pe
 
 	zend_attribute *attr = pemalloc(ZEND_ATTRIBUTE_SIZE(argc), persistent);
 
-	if (persistent == (zend_bool) (GC_FLAGS(name) & IS_STR_PERSISTENT)) {
+	if (persistent == ((GC_FLAGS(name) & IS_STR_PERSISTENT) != 0)) {
 		attr->name = zend_string_copy(name);
 	} else {
 		attr->name = zend_string_dup(name, persistent);

--- a/Zend/zend_attributes.c
+++ b/Zend/zend_attributes.c
@@ -18,20 +18,6 @@ ZEND_API zend_attributes_internal_validator zend_attribute_get_validator(zend_st
 	return zend_hash_find_ptr(&internal_validators, lcname);
 }
 
-ZEND_API void zend_attribute_free(zend_attribute *attr, int persistent)
-{
-	uint32_t i;
-
-	zend_string_release(attr->name);
-	zend_string_release(attr->lcname);
-
-	for (i = 0; i < attr->argc; i++) {
-		zval_ptr_dtor(&attr->argv[i]);
-	}
-
-	pefree(attr, persistent);
-}
-
 static zend_attribute *get_attribute(HashTable *attributes, zend_string *lcname, uint32_t offset)
 {
 	if (attributes) {
@@ -84,9 +70,52 @@ ZEND_API zend_attribute *zend_get_parameter_attribute_str(HashTable *attributes,
 	return get_attribute_str(attributes, str, len, offset + 1);
 }
 
-static void attribute_ptr_dtor(zval *v)
+static zend_always_inline void free_attribute(zend_attribute *attr, int persistent)
 {
-	zend_attribute_free((zend_attribute *) Z_PTR_P(v), 1);
+	uint32_t i;
+
+	zend_string_release(attr->name);
+	zend_string_release(attr->lcname);
+
+	for (i = 0; i < attr->argc; i++) {
+		zval_ptr_dtor(&attr->argv[i]);
+	}
+
+	pefree(attr, persistent);
+}
+
+static void attr_free(zval *v)
+{
+	free_attribute((zend_attribute *) Z_PTR_P(v), 0);
+}
+
+static void attr_pfree(zval *v)
+{
+	free_attribute((zend_attribute *) Z_PTR_P(v), 1);
+}
+
+ZEND_API zend_attribute *zend_add_attribute(HashTable **attributes, zend_bool persistent, uint32_t offset, zend_string *name, uint32_t argc)
+{
+	if (*attributes == NULL) {
+		*attributes = pemalloc(sizeof(HashTable), persistent);
+		zend_hash_init(*attributes, 8, NULL, persistent ? attr_pfree : attr_free, persistent);
+	}
+
+	zend_attribute *attr = pemalloc(ZEND_ATTRIBUTE_SIZE(argc), persistent);
+
+	if (persistent == (zend_bool) (GC_FLAGS(name) & IS_STR_PERSISTENT)) {
+		attr->name = zend_string_copy(name);
+	} else {
+		attr->name = zend_string_dup(name, persistent);
+	}
+
+	attr->lcname = zend_string_tolower_ex(attr->name, persistent);
+	attr->offset = offset;
+	attr->argc = argc;
+
+	zend_hash_next_index_insert_ptr(*attributes, attr);
+
+	return attr;
 }
 
 ZEND_API void zend_compiler_attribute_register(zend_class_entry *ce, zend_attributes_internal_validator validator)
@@ -100,19 +129,7 @@ ZEND_API void zend_compiler_attribute_register(zend_class_entry *ce, zend_attrib
 	zend_hash_update_ptr(&internal_validators, lcname, validator);
 	zend_string_release(lcname);
 
-	if (ce->attributes == NULL) {
-		ce->attributes = pemalloc(sizeof(HashTable), 1);
-		zend_hash_init(ce->attributes, 8, NULL, attribute_ptr_dtor, 1);
-	}
-
-	zend_attribute *attr = pemalloc(ZEND_ATTRIBUTE_SIZE(0), 1);
-
-	attr->name = zend_string_copy(zend_ce_php_attribute->name);
-	attr->lcname = zend_string_tolower_ex(attr->name, 1);
-	attr->offset = 0;
-	attr->argc = 0;
-
-	zend_hash_next_index_insert_ptr(ce->attributes, attr);
+	zend_add_class_attribute(ce, zend_ce_php_attribute->name, 0);
 }
 
 void zend_register_attribute_ce(void)

--- a/Zend/zend_attributes.h
+++ b/Zend/zend_attributes.h
@@ -59,32 +59,8 @@ static zend_always_inline zend_attribute *zend_add_property_attribute(zend_class
 	return zend_add_attribute(&info->attributes, ce->type != ZEND_USER_CLASS, 0, name, argc);
 }
 
-static zend_always_inline zend_attribute *zend_add_property_attribute_str(zend_class_entry *ce, const char *key, size_t len, zend_string *name, uint32_t argc)
-{
-	zend_property_info *info = (zend_property_info *) zend_hash_str_find_ptr(&ce->properties_info, key, len);
-
-	if (info == NULL) {
-		zend_error_noreturn(E_ERROR, "Property '%.*s' not found in class '%s'", (int) len, key, ZSTR_VAL(ce->name));
-		return NULL;
-	}
-
-	return zend_add_attribute(&info->attributes, ce->type != ZEND_USER_CLASS, 0, name, argc);
-}
-
 static zend_always_inline zend_attribute *zend_add_class_constant_attribute(zend_class_entry *ce, zend_class_constant *c, zend_string *name, uint32_t argc)
 {
-	return zend_add_attribute(&c->attributes, ce->type != ZEND_USER_CLASS, 0, name, argc);
-}
-
-static zend_always_inline zend_attribute *zend_add_class_constant_attribute_str(zend_class_entry *ce, const char *key, size_t len, zend_string *name, uint32_t argc)
-{
-	zend_class_constant *c = (zend_class_constant *) zend_hash_str_find_ptr(&ce->constants_table, key, len);
-
-	if (c == NULL) {
-		zend_error_noreturn(E_ERROR, "Class constant '%.*s' not found in class '%s'", (int) len, key, ZSTR_VAL(ce->name));
-		return NULL;
-	}
-
 	return zend_add_attribute(&c->attributes, ce->type != ZEND_USER_CLASS, 0, name, argc);
 }
 

--- a/Zend/zend_compile.c
+++ b/Zend/zend_compile.c
@@ -6439,6 +6439,7 @@ void zend_compile_prop_decl(zend_ast *ast, zend_ast *type_ast, uint32_t flags, z
 	}
 
 	for (i = 0; i < children; ++i) {
+		zend_property_info *info;
 		zend_ast *prop_ast = list->child[i];
 		zend_ast *name_ast = prop_ast->child[0];
 		zend_ast *value_ast = prop_ast->child[1];
@@ -6499,10 +6500,9 @@ void zend_compile_prop_decl(zend_ast *ast, zend_ast *type_ast, uint32_t flags, z
 			ZVAL_UNDEF(&value_zv);
 		}
 
-		zend_declare_typed_property(ce, name, &value_zv, flags, doc_comment, type);
+		info = zend_declare_typed_property(ce, name, &value_zv, flags, doc_comment, type);
 
 		if (attr_ast) {
-			zend_property_info *info = (zend_property_info *) zend_hash_find_ptr(&ce->properties_info, name);
 			zend_compile_attributes(&info->attributes, attr_ast, 0, ZEND_ATTRIBUTE_TARGET_PROPERTY);
 		}
 	}
@@ -6553,6 +6553,7 @@ void zend_compile_class_const_decl(zend_ast *ast, zend_ast *attr_ast) /* {{{ */
 	}
 
 	for (i = 0; i < list->children; ++i) {
+		zend_class_constant *c;
 		zend_ast *const_ast = list->child[i];
 		zend_ast *name_ast = const_ast->child[0];
 		zend_ast *value_ast = const_ast->child[1];
@@ -6566,10 +6567,9 @@ void zend_compile_class_const_decl(zend_ast *ast, zend_ast *attr_ast) /* {{{ */
 		}
 
 		zend_const_expr_to_zval(&value_zv, value_ast);
-		zend_declare_class_constant_ex(ce, name, &value_zv, ast->attr, doc_comment);
+		c = zend_declare_class_constant_ex(ce, name, &value_zv, ast->attr, doc_comment);
 
 		if (attr_ast) {
-			zend_class_constant *c = (zend_class_constant *) zend_hash_find_ptr(&ce->constants_table, name);
 			zend_compile_attributes(&c->attributes, attr_ast, 0, ZEND_ATTRIBUTE_TARGET_CLASS_CONST);
 		}
 	}

--- a/Zend/zend_inheritance.c
+++ b/Zend/zend_inheritance.c
@@ -1973,7 +1973,6 @@ static void zend_do_traits_property_binding(zend_class_entry *ce, zend_class_ent
 	zval* prop_value;
 	uint32_t flags;
 	zend_string *doc_comment;
-	HashTable *attributes = NULL;
 
 	/* In the following steps the properties are inserted into the property table
 	 * for that, a very strict approach is applied:
@@ -2073,15 +2072,19 @@ static void zend_do_traits_property_binding(zend_class_entry *ce, zend_class_ent
 
 			Z_TRY_ADDREF_P(prop_value);
 			doc_comment = property_info->doc_comment ? zend_string_copy(property_info->doc_comment) : NULL;
-			if (property_info->attributes) {
-				attributes = property_info->attributes;
 
-				if (!(GC_FLAGS(attributes) & IS_ARRAY_IMMUTABLE)) {
-					GC_ADDREF(attributes);
+			zend_type_copy_ctor(&property_info->type, /* persistent */ 0);
+			zend_declare_typed_property(ce, prop_name, prop_value, flags, doc_comment, property_info->type);
+
+			if (property_info->attributes) {
+				zend_property_info *info = (zend_property_info *) zend_hash_find_ptr(&ce->properties_info, prop_name);
+				info->attributes = property_info->attributes;
+
+				if (!(GC_FLAGS(info->attributes) & IS_ARRAY_IMMUTABLE)) {
+					GC_ADDREF(info->attributes);
 				}
 			}
-			zend_type_copy_ctor(&property_info->type, /* persistent */ 0);
-			zend_declare_typed_property(ce, prop_name, prop_value, flags, doc_comment, attributes, property_info->type);
+
 			zend_string_release_ex(prop_name, 0);
 		} ZEND_HASH_FOREACH_END();
 	}

--- a/Zend/zend_inheritance.c
+++ b/Zend/zend_inheritance.c
@@ -1967,6 +1967,7 @@ static void zend_do_traits_property_binding(zend_class_entry *ce, zend_class_ent
 	size_t i;
 	zend_property_info *property_info;
 	zend_property_info *coliding_prop;
+	zend_property_info *new_prop;
 	zend_string* prop_name;
 	const char* class_name_unused;
 	zend_bool not_compatible;
@@ -2074,14 +2075,13 @@ static void zend_do_traits_property_binding(zend_class_entry *ce, zend_class_ent
 			doc_comment = property_info->doc_comment ? zend_string_copy(property_info->doc_comment) : NULL;
 
 			zend_type_copy_ctor(&property_info->type, /* persistent */ 0);
-			zend_declare_typed_property(ce, prop_name, prop_value, flags, doc_comment, property_info->type);
+			new_prop = zend_declare_typed_property(ce, prop_name, prop_value, flags, doc_comment, property_info->type);
 
 			if (property_info->attributes) {
-				zend_property_info *info = (zend_property_info *) zend_hash_find_ptr(&ce->properties_info, prop_name);
-				info->attributes = property_info->attributes;
+				new_prop->attributes = property_info->attributes;
 
-				if (!(GC_FLAGS(info->attributes) & IS_ARRAY_IMMUTABLE)) {
-					GC_ADDREF(info->attributes);
+				if (!(GC_FLAGS(new_prop->attributes) & IS_ARRAY_IMMUTABLE)) {
+					GC_ADDREF(new_prop->attributes);
 				}
 			}
 

--- a/ext/tokenizer/tokenizer.c
+++ b/ext/tokenizer/tokenizer.c
@@ -266,22 +266,22 @@ PHP_MINIT_FUNCTION(tokenizer)
 	zend_class_implements(php_token_ce, 1, zend_ce_stringable);
 
 	name = zend_string_init("id", sizeof("id") - 1, 1);
-	zend_declare_typed_property(php_token_ce, name, &default_val, ZEND_ACC_PUBLIC, NULL, NULL,
+	zend_declare_typed_property(php_token_ce, name, &default_val, ZEND_ACC_PUBLIC, NULL,
 		(zend_type) ZEND_TYPE_INIT_MASK(MAY_BE_LONG));
 	zend_string_release(name);
 
 	name = zend_string_init("text", sizeof("text") - 1, 1);
-	zend_declare_typed_property(php_token_ce, name, &default_val, ZEND_ACC_PUBLIC, NULL, NULL,
+	zend_declare_typed_property(php_token_ce, name, &default_val, ZEND_ACC_PUBLIC, NULL,
 		(zend_type) ZEND_TYPE_INIT_MASK(MAY_BE_STRING));
 	zend_string_release(name);
 
 	name = zend_string_init("line", sizeof("line") - 1, 1);
-	zend_declare_typed_property(php_token_ce, name, &default_val, ZEND_ACC_PUBLIC, NULL, NULL,
+	zend_declare_typed_property(php_token_ce, name, &default_val, ZEND_ACC_PUBLIC, NULL,
 		(zend_type) ZEND_TYPE_INIT_MASK(MAY_BE_LONG));
 	zend_string_release(name);
 
 	name = zend_string_init("pos", sizeof("pos") - 1, 1);
-	zend_declare_typed_property(php_token_ce, name, &default_val, ZEND_ACC_PUBLIC, NULL, NULL,
+	zend_declare_typed_property(php_token_ce, name, &default_val, ZEND_ACC_PUBLIC, NULL,
 		(zend_type) ZEND_TYPE_INIT_MASK(MAY_BE_LONG));
 	zend_string_release(name);
 

--- a/ext/zend_test/test.c
+++ b/ext/zend_test/test.c
@@ -226,7 +226,7 @@ PHP_MINIT_FUNCTION(zend_test)
 		zval val;
 		ZVAL_LONG(&val, 123);
 		zend_declare_typed_property(
-			zend_test_class, name, &val, ZEND_ACC_PUBLIC, NULL, NULL,
+			zend_test_class, name, &val, ZEND_ACC_PUBLIC, NULL,
 			(zend_type) ZEND_TYPE_INIT_CODE(IS_LONG, 0, 0));
 		zend_string_release(name);
 	}
@@ -237,7 +237,7 @@ PHP_MINIT_FUNCTION(zend_test)
 		zval val;
 		ZVAL_NULL(&val);
 		zend_declare_typed_property(
-			zend_test_class, name, &val, ZEND_ACC_PUBLIC, NULL, NULL,
+			zend_test_class, name, &val, ZEND_ACC_PUBLIC, NULL,
 			(zend_type) ZEND_TYPE_INIT_CLASS(class_name, 1, 0));
 		zend_string_release(name);
 	}
@@ -253,7 +253,7 @@ PHP_MINIT_FUNCTION(zend_test)
 		zend_type type = ZEND_TYPE_INIT_PTR(type_list, _ZEND_TYPE_LIST_BIT, 1, 0);
 		zval val;
 		ZVAL_NULL(&val);
-		zend_declare_typed_property(zend_test_class, name, &val, ZEND_ACC_PUBLIC, NULL, NULL, type);
+		zend_declare_typed_property(zend_test_class, name, &val, ZEND_ACC_PUBLIC, NULL, type);
 		zend_string_release(name);
 	}
 
@@ -262,7 +262,7 @@ PHP_MINIT_FUNCTION(zend_test)
 		zval val;
 		ZVAL_LONG(&val, 123);
 		zend_declare_typed_property(
-			zend_test_class, name, &val, ZEND_ACC_PUBLIC | ZEND_ACC_STATIC, NULL, NULL,
+			zend_test_class, name, &val, ZEND_ACC_PUBLIC | ZEND_ACC_STATIC, NULL,
 			(zend_type) ZEND_TYPE_INIT_CODE(IS_LONG, 0, 0));
 		zend_string_release(name);
 	}

--- a/ext/zip/php_zip.c
+++ b/ext/zip/php_zip.c
@@ -819,7 +819,7 @@ static void php_zip_register_prop_handler(HashTable *prop_handler, char *name, z
 
 	/* Register for reflection */
 	ZVAL_NULL(&tmp);
-	zend_declare_property_ex(zip_class_entry, str, &tmp, ZEND_ACC_PUBLIC, NULL, NULL);
+	zend_declare_property_ex(zip_class_entry, str, &tmp, ZEND_ACC_PUBLIC, NULL);
 	zend_string_release_ex(str, 1);
 }
 /* }}} */


### PR DESCRIPTION
This PR avoids modifications to existing Zend APIs by providing attribute registration functions. This was suggested by @nikic in the attributes v2 PR. All the work is done by `zend_add_attribute()` and some very small inline helper functions have been added to `zend_attributes.h` to deal with most common use cases.

The compiler has been adjusted make use of the new API. The changes ensure that all attributes (and arrays) are allocated in `zend_attributes.c`. This keeps the code in one place. It also enabled me to erase `zend_attribute_free()` from the public API because it is only needed internally.