### PR TITLE
Fix Attribute Test Errors

### DIFF
--- a/Zend/tests/attributes/003_ast_nodes.phpt
+++ b/Zend/tests/attributes/003_ast_nodes.phpt
@@ -65,7 +65,7 @@ class C5
 	public function __construct() { }
 }
 
-$ref = new \ReflectionFunction(@[C5(MissingClass::SOME_CONST) function () { });
+$ref = new \ReflectionFunction(@[C5(MissingClass::SOME_CONST)] function () { });
 $attr = $ref->getAttributes();
 var_dump(count($attr));
 

--- a/Zend/tests/attributes/005_objects.phpt
+++ b/Zend/tests/attributes/005_objects.phpt
@@ -26,7 +26,7 @@ foreach ($ref->getAttributes() as $attr) {
 
 echo "\n";
 
-$ref = new \ReflectionFunction(@[A1 function] () { });
+$ref = new \ReflectionFunction(@[A1] function () { });
 
 try {
 	$ref->getAttributes()[0]->newInstance();
@@ -75,7 +75,7 @@ echo "\n";
 @[Attribute]
 class A4 { }
 
-$ref = new \ReflectionFunction(@[A4(1) function () { });
+$ref = new \ReflectionFunction(@[A4(1)] function () { });
 
 try {
 	$ref->getAttributes()[0]->newInstance();

--- a/Zend/tests/attributes/012_ast_export.phpt
+++ b/Zend/tests/attributes/012_ast_export.phpt
@@ -3,9 +3,9 @@ Attributes AST can be exported.
 --FILE--
 <?php
 
-assert(0 && ($a = @[A1] @[A2] function ($a, @[A3](1) $b) { }));
+assert(0 && ($a = @[A1] @[A2] function ($a, @[A3(1)] $b) { }));
 
-assert(0 && ($a = @[A1](1, 2, 1 + 2) fn () => 1));
+assert(0 && ($a = @[A1(1, 2, 1 + 2)] fn () => 1));
 
 assert(0 && ($a = new @[A1] class() {
 	@[A1]@[A2] const FOO = 'foo';
@@ -21,10 +21,10 @@ assert(0 && ($a = function () {
 
 ?>
 --EXPECTF--
-Warning: assert(): assert(0 && ($a = @[A1] @[A2] function ($a, @[A3](1) $b) {
+Warning: assert(): assert(0 && ($a = @[A1] @[A2] function ($a, @[A3(1)] $b) {
 })) failed in %s on line %d
 
-Warning: assert(): assert(0 && ($a = @[A1](1, 2, 1 + 2) fn() => 1)) failed in %s on line %d
+Warning: assert(): assert(0 && ($a = @[A1(1, 2, 1 + 2)] fn() => 1)) failed in %s on line %d
 
 Warning: assert(): assert(0 && ($a = new @[A1] class {
     @[A1]

--- a/Zend/tests/attributes/020_userland_attribute_validation.phpt
+++ b/Zend/tests/attributes/020_userland_attribute_validation.phpt
@@ -37,7 +37,7 @@ try {
 
 echo "\n";
 
-@[Attribute(Attribute::TARGET_CLASS | Attribute::IS_REPEATABLE)
+@[Attribute(Attribute::TARGET_CLASS | Attribute::IS_REPEATABLE)]
 class A2 { }
 
 $ref = new \ReflectionObject(new @[A2] @[A2] class() { });
@@ -56,13 +56,13 @@ string(2) "A1"
 bool(true)
 bool(false)
 string(7) "ERROR 1"
-string(70) "Attribute "A1]" cannot target class (allowed targets: function, method)"
+string(70) "Attribute "A1" cannot target class (allowed targets: function, method)"
 
 string(2) "A1"
 bool(true)
 bool(true)
 string(7) "ERROR 2"
-string(35) "Attribute "A1]" must not be repeated"
+string(35) "Attribute "A1" must not be repeated"
 
 string(2) "A2"
 bool(true)

--- a/Zend/tests/ctor_promotion_attributes.phpt
+++ b/Zend/tests/ctor_promotion_attributes.phpt
@@ -5,7 +5,7 @@ Attributes on promoted properties are assigned to both the property and paramete
 
 class Test {
     public function __construct(
-        @@NonNegative
+        @[NonNegative]
         public int $num,
     ) {}
 }

--- a/ext/tokenizer/tests/attributes.phpt
+++ b/ext/tokenizer/tests/attributes.phpt
@@ -3,7 +3,7 @@ Attributes are exposed as tokens.
 --FILE--
 <?php
 
-$tokens = token_get_all('<?php @@A1(1, 2) class C1 { }');
+$tokens = token_get_all('<?php @[A1(1, 2)] class C1 { }');
 
 $attr = $tokens[1];
 var_dump(token_name(T_ATTRIBUTE));
@@ -16,5 +16,5 @@ var_dump($class[1]);
 --EXPECT--
 string(11) "T_ATTRIBUTE"
 bool(true)
-string(2) "@@"
+string(2) "@["
 string(2) "A1"

--- a/ext/zend_test/test.c
+++ b/ext/zend_test/test.c
@@ -257,7 +257,7 @@ static zend_function *zend_test_class_static_method_get(zend_class_entry *ce, ze
 void zend_attribute_validate_zendtestattribute(zend_attribute *attr, uint32_t target, zend_class_entry *scope)
 {
 	if (target != ZEND_ATTRIBUTE_TARGET_CLASS) {
-		zend_error(E_COMPILE_ERROR, "Only classes can be marked with @@ZendTestAttribute");
+		zend_error(E_COMPILE_ERROR, "Only classes can be marked with @[ZendTestAttribute]");
 	}
 }
 


### PR DESCRIPTION
Fixes all attribute-related errors in your `AtRustySyntax` branch. You need to rebase your branch on current PHP master after merging this and fix the following test cases (most of them related to named arguments):

```
bug79897: Promoted constructor params with attribs cause crash [Zend/tests/bug79897.phpt]
Named params in attributes: Positional after named error [Zend/tests/named_params/attributes_positional_after_named.phpt]
Named params in attributes [Zend/tests/named_params/attributes.phpt]
Named params in attributes: Duplicate named parameter error [Zend/tests/named_params/attributes_duplicate_named_param.phpt]
Named flags parameter for Attribute attribute [Zend/tests/named_params/attributes_named_flags.phpt]
Named flags parameter for Attribute attribute (incorrect parameter name) [Zend/tests/named_params/attributes_named_flags_incorrect.phpt]
```
